### PR TITLE
Correctifs sur l'authentification des élèves

### DIFF
--- a/web/flaskr/routes.py
+++ b/web/flaskr/routes.py
@@ -1382,15 +1382,18 @@ def authenticate_then_signin_meeting(meeting_fake_id, user_id, h):
 
 
 @bp.route(
-    "/meeting/wait/<meeting_fake_id>/creator/<int:user_id>/hash/<h>/fullname/<path:fullname>/fullname_suffix/",
-    methods=["GET"],
-    defaults={"fullname_suffix": ""},
+    "/meeting/wait/<meeting_fake_id>/creator/<user_id>/hash/<h>/fullname/fullname_suffix/",
 )
 @bp.route(
-    "/meeting/wait/<meeting_fake_id>/creator/<int:user_id>/hash/<h>/fullname/<path:fullname>/fullname_suffix/<path:fullname_suffix>",
-    methods=["GET"],
+    "/meeting/wait/<meeting_fake_id>/creator/<user_id>/hash/<h>/fullname/<path:fullname>/fullname_suffix/",
 )
-def waiting_meeting(meeting_fake_id, user_id, h, fullname, fullname_suffix):
+@bp.route(
+    "/meeting/wait/<meeting_fake_id>/creator/<user_id>/hash/<h>/fullname/fullname_suffix/<path:fullname_suffix>",
+)
+@bp.route(
+    "/meeting/wait/<meeting_fake_id>/creator/<user_id>/hash/<h>/fullname/<path:fullname>/fullname_suffix/<path:fullname_suffix>",
+)
+def waiting_meeting(meeting_fake_id, user_id, h, fullname="", fullname_suffix=""):
     meeting = get_meeting_from_meeting_id_and_user_id(meeting_fake_id, user_id)
     if meeting is None:
         return redirect("/")
@@ -1501,7 +1504,6 @@ def join_meeting_as_authenticated(meeting_id):
             user_id=meeting.user.id,
             h=meeting.get_hash(role),
             fullname=fullname,
-            fullname_suffix="",
         )
     )
 

--- a/web/flaskr/routes.py
+++ b/web/flaskr/routes.py
@@ -110,10 +110,7 @@ attendee_provider_configuration = ProviderConfiguration(
         ),
         post_logout_redirect_uris=[f'{current_app.config.get("SERVER_FQDN")}/logout'],
     ),
-    auth_request_params={
-        "scope": current_app.config.get("OIDC_ATTENDEE_SCOPES")
-        or current_app.config["OIDC_SCOPES"]
-    },
+    auth_request_params={"scope": current_app.config["OIDC_ATTENDEE_SCOPES"]},
 )
 
 auth = OIDCAuthentication(

--- a/web/flaskr/routes.py
+++ b/web/flaskr/routes.py
@@ -1482,9 +1482,9 @@ def join_mail_meeting():
 def get_authenticated_attendee_fullname():
     attendee_session = UserSession(session)
     attendee_info = attendee_session.userinfo
-    given_name = attendee_info["given_name"]
-    family_name = attendee_info["family_name"]
-    fullname = f"{given_name} {family_name}"
+    given_name = attendee_info.get("given_name", "")
+    family_name = attendee_info.get("family_name", "")
+    fullname = f"{given_name} {family_name}".strip()
     return fullname
 
 

--- a/web/instance/config.py
+++ b/web/instance/config.py
@@ -32,7 +32,15 @@ OIDC_ID_TOKEN_COOKIE_SECURE = False
 OIDC_REQUIRE_VERIFIED_EMAIL = False
 OIDC_USER_INFO_ENABLED = True
 OIDC_OPENID_REALM = os.environ.get("OIDC_OPENID_REALM")
-OIDC_SCOPES = ["openid", "email", "profile"]
+OIDC_SCOPES = (
+    list(map(str.strip, os.environ["OIDC_SCOPES"].split(",")))
+    if os.environ.get("OIDC_SCOPES")
+    else [
+        "openid",
+        "email",
+        "profile",
+    ]
+)
 OIDC_INTROSPECTION_AUTH_METHOD = "client_secret_post"
 OIDC_USERINFO_HTTP_METHOD = os.environ.get("OIDC_USERINFO_HTTP_METHOD")
 OIDC_INFO_REQUESTED_FIELDS = ["email", "given_name", "family_name"]
@@ -69,6 +77,11 @@ OIDC_ATTENDEE_USERINFO_HTTP_METHOD = (
 )
 OIDC_ATTENDEE_SERVICE_NAME = (
     os.environ.get("OIDC_ATTENDEE_SERVICE_NAME") or OIDC_SERVICE_NAME
+)
+OIDC_ATTENDEE_SCOPES = (
+    list(map(str.strip, os.environ["OIDC_ATTENDEE_SCOPES"].split(",")))
+    if os.environ.get("OIDC_ATTENDEE_SCOPES")
+    else OIDC_SCOPES
 )
 
 # Links


### PR DESCRIPTION
Cette PR 
- évite les crashes en cas de mauvaise configuration de l'authentification des participants au séminaire, lorsque le code tente d'accéder à leurs noms et prénoms
- autorise la définition de variables d'environnement `OIDC_SCOPES` et `OIDC_ATTENDEE_SCOPES` pour paramétrer les champs demandés en lecture dans les profils utilisateurs à l'authentification. S'ils sont définis en tant que variables d'environnements, ils doivent prendre la forme d'une chaîne de caractère unique composée de plusieurs valeurs séparées par des virgules, par exemple : `
OIDC_SCOPES="openid, email, profile"`

fixes #8 