### PR TITLE
BBB %%CONFNAME%% variable substitution

### DIFF
--- a/web/flaskr/forms.py
+++ b/web/flaskr/forms.py
@@ -74,8 +74,9 @@ class MeetingForm(FlaskForm):
             "Ce texte apparait comme message de bienvenue sur le tchat public"
         ),
         default=lazy_gettext(
-            "Bienvenue dans %(this_meeting)s <u><strong> %%CONFNAME%% </strong></u>.",
+            "Bienvenue dans %(this_meeting)s %(meeting_name)s.",
             this_meeting=current_app.config["WORDING_THIS_MEETING"],
+            meeting_name="<u><strong> %%CONFNAME%% </strong></u>",
         ),
         render_kw={"rows": 3},
         validators=[

--- a/web/translations/en/LC_MESSAGES/messages.po
+++ b/web/translations/en/LC_MESSAGES/messages.po
@@ -43,8 +43,8 @@ msgstr "This text is displayed as a welcome message on the public chat"
 
 #: web/flaskr/forms.py:75
 #, python-format
-msgid "Bienvenue dans %(this_meeting)s <u><strong> %%CONFNAME%% </strong></u>."
-msgstr "Welcome in this meeting <u><strong> %%CONFNAME%% </strong></u>."
+msgid "Bienvenue dans %(this_meeting)s %(meeting_name)s."
+msgstr "Welcome in this meeting %(meeting_name)s."
 
 #: web/flaskr/forms.py:81
 msgid "Le texte est trop long"

--- a/web/translations/fr/LC_MESSAGES/messages.po
+++ b/web/translations/fr/LC_MESSAGES/messages.po
@@ -43,7 +43,7 @@ msgstr ""
 
 #: web/flaskr/forms.py:75
 #, python-format
-msgid "Bienvenue dans %(this_meeting)s <u><strong> %%CONFNAME%% </strong></u>."
+msgid "Bienvenue dans %(this_meeting)s %(meeting_name)s."
 msgstr ""
 
 #: web/flaskr/forms.py:81

--- a/web/translations/messages.pot
+++ b/web/translations/messages.pot
@@ -42,7 +42,7 @@ msgstr ""
 
 #: web/flaskr/forms.py:75
 #, python-format
-msgid "Bienvenue dans %(this_meeting)s <u><strong> %%CONFNAME%% </strong></u>."
+msgid "Bienvenue dans %(this_meeting)s %(meeting_name)s."
 msgstr ""
 
 #: web/flaskr/forms.py:81

--- a/web/translations/uk/LC_MESSAGES/messages.po
+++ b/web/translations/uk/LC_MESSAGES/messages.po
@@ -44,7 +44,7 @@ msgstr ""
 
 #: web/flaskr/forms.py:75
 #, python-format
-msgid "Bienvenue dans %(this_meeting)s <u><strong> %%CONFNAME%% </strong></u>."
+msgid "Bienvenue dans %(this_meeting)s %(meeting_name)s."
 msgstr ""
 
 #: web/flaskr/forms.py:81


### PR DESCRIPTION
Le double % est corrigé dans la description des nouveaux séminaires.

Pour ceux créées avant l'application de ce patch, il faut éditer manuellement la description:

![Screenshot 2023-08-16 at 09-50-04 Screenshot](https://github.com/numerique-gouv/b3desk/assets/60163/e494fcc9-8082-41aa-9343-3abf10c2df13)

fixes #8