### PR TITLE
Réusinage de la variable `is_rie`

### DIFF
--- a/web/flaskr/__init__.py
+++ b/web/flaskr/__init__.py
@@ -17,6 +17,7 @@ from flask import session
 from flask_babel import Babel
 from flask_migrate import Migrate
 from flask_wtf.csrf import CSRFProtect
+from flaskr.utils import is_rie
 
 from .common.extensions import cache
 
@@ -58,6 +59,7 @@ def create_app(test_config=None, gunicorn_logging=False):
             "config": app.config,
             "beta": app.config["BETA"],
             "documentation_link": app.config["DOCUMENTATION_LINK"],
+            "is_rie": is_rie(),
             "LANGUAGES": LANGUAGES,
             **app.config["WORDINGS"],
         }

--- a/web/flaskr/routes.py
+++ b/web/flaskr/routes.py
@@ -58,8 +58,6 @@ from flaskr.models import MeetingFiles
 from flaskr.models import MeetingFilesExternal
 from flaskr.models import User
 from flaskr.utils import retry_join_meeting
-from netaddr import IPAddress
-from netaddr import IPNetwork
 from sqlalchemy import exc
 from webdav3.client import Client as webdavClient
 from webdav3.exceptions import WebDavException
@@ -377,16 +375,10 @@ def index():
 def home():
     if has_user_session():
         return redirect(url_for("routes.welcome"))
-    is_rie = any(
-        [
-            IPAddress(request.remote_addr) in IPNetwork(network_ip)
-            for network_ip in current_app.config["RIE_NETWORK_IPS"]
-        ]
-    )
+
     stats = get_meetings_stats()
     return render_template(
         "index.html",
-        is_rie=is_rie,
         stats=stats,
         mail_meeting=current_app.config["MAIL_MEETING"],
         max_participants=current_app.config["MAX_PARTICIPANTS"],
@@ -1262,12 +1254,6 @@ def ncdownload(isexternal, mfid, mftoken):
     methods=["GET"],
 )
 def signin_mail_meeting(meeting_fake_id, expiration, h):
-    is_rie = any(
-        [
-            IPAddress(request.remote_addr) in IPNetwork(network_ip)
-            for network_ip in current_app.config["RIE_NETWORK_IPS"]
-        ]
-    )
     meeting = get_mail_meeting(meeting_fake_id)
     wordings = current_app.config["WORDINGS"]
 
@@ -1298,7 +1284,6 @@ def signin_mail_meeting(meeting_fake_id, expiration, h):
         expiration=expiration,
         user_id="fakeuserId",
         h=h,
-        is_rie=is_rie,
         role="moderator",
     )
 
@@ -1307,12 +1292,6 @@ def signin_mail_meeting(meeting_fake_id, expiration, h):
     "/meeting/signin/<meeting_fake_id>/creator/<int:user_id>/hash/<h>", methods=["GET"]
 )
 def signin_meeting(meeting_fake_id, user_id, h):
-    is_rie = any(
-        [
-            IPAddress(request.remote_addr) in IPNetwork(network_ip)
-            for network_ip in current_app.config["RIE_NETWORK_IPS"]
-        ]
-    )
     meeting = get_meeting_from_meeting_id_and_user_id(meeting_fake_id, user_id)
     wordings = current_app.config["WORDINGS"]
     if meeting is None:
@@ -1340,7 +1319,6 @@ def signin_meeting(meeting_fake_id, user_id, h):
         meeting_fake_id=meeting_fake_id,
         user_id=user_id,
         h=h,
-        is_rie=is_rie,
         role=role,
     )
 

--- a/web/flaskr/utils.py
+++ b/web/flaskr/utils.py
@@ -1,4 +1,7 @@
 from flask import current_app
+from flask import request
+from netaddr import IPAddress
+from netaddr import IPNetwork
 
 
 def secret_key():
@@ -10,4 +13,19 @@ def retry_join_meeting(referrer, role, fullname, fullname_suffix):
         (referrer and "/meeting/wait/" in referrer)
         or (role in ("attendee", "moderator") and fullname)
         or (role == "authenticated" and fullname and fullname_suffix)
+    )
+
+
+def is_rie():
+    """
+    Checks wether the request was made from inside the state network
+    "Réseau Interministériel de l’État"
+    """
+    if not request.remote_addr:
+        return False
+
+    return any(
+        IPAddress(request.remote_addr) in IPNetwork(network_ip)
+        for network_ip in current_app.config.get("RIE_NETWORK_IPS", [])
+        if network_ip
     )


### PR DESCRIPTION
La variable `is_rie` qui détecte si l'utilisateur se connecte depuis le réseau interministériel de l'état est définie à un seul endroit, et est disponible pour toutes les vues.
Cela supprime de la redondance du code et les possibles erreurs qui peuvent en découler.