### PR TITLE
URL du formulaire de satisfaction configurable

### DIFF
--- a/web.env.example
+++ b/web.env.example
@@ -14,6 +14,7 @@ SERVICE_TITLE=Webinaire
 SERVICE_TAGLINE=Le service de webinaire
 
 MEETING_LOGOUT_URL=
+SATISFACTION_POLL_URL=https://dinum.evalandgo.com/s/index.php?id=JTk4ciU5Mm0lOTclQjE=&a=JTk2byU5NmglOUUlQUI=
 
 WORDING_MEETING_PRESENTATION=présentation
 WORDING_UPLOAD_FILE=envoyer

--- a/web/flaskr/templates/meeting/list.html
+++ b/web/flaskr/templates/meeting/list.html
@@ -20,10 +20,10 @@
   </div>
   {% include 'meeting/modals.html' %}
   {% endfor %}
-  {% if meetings|length %}
+  {% if meetings|length and config.get("SATISFACTION_POLL_URL") %}
     <iframe id="iframe-poll"
       frameborder=0
-      src="https://dinum.evalandgo.com/s/index.php?id=JTk4ciU5Mm0lOTclQjE=&a=JTk2byU5NmglOUUlQUI="
+      src="{{ config.get("SATISFACTION_POLL_URL") }}"
       height="500" scrolling="no"
       sandbox="allow-scripts allow-same-origin allow-forms"></iframe>
   {% endif %}

--- a/web/instance/config.py
+++ b/web/instance/config.py
@@ -96,6 +96,7 @@ SERVICE_TITLE = os.environ.get("SERVICE_TITLE")
 SERVICE_TAGLINE = os.environ.get("SERVICE_TAGLINE")
 
 MEETING_LOGOUT_URL = os.environ.get("MEETING_LOGOUT_URL", "")
+SATISFACTION_POLL_URL = os.environ.get("SATISFACTION_POLL_URL")
 
 # Database configuration
 SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")

--- a/web/tests/test_satisfaction_poll.py
+++ b/web/tests/test_satisfaction_poll.py
@@ -1,0 +1,10 @@
+def test_no_satisfaction_poll(client_app, authenticated_user, bbb_response):
+    res = client_app.get("/welcome")
+    res.mustcontain(no="iframe")
+
+
+def test_satisfaction_poll_url(client_app, authenticated_user, meeting, bbb_response):
+    client_app.app.config["SATISFACTION_POLL_URL"] = "https://poll.example.org"
+    res = client_app.get("/welcome")
+    res.mustcontain("iframe")
+    res.mustcontain("https://poll.example.org")


### PR DESCRIPTION
Ce patch introduit un nouveau paramètre de configuration `SATISFACTION_POLL_URL` qui permet définir l'URL du sondage de satisfaction à afficher. Si le paramètre n'est pas défini alors aucun sondage n'est affiché.

:warning: Attention :warning:
Ce paramètre est vide par défaut, il faut penser à configurer `SATISFACTION_POLL_URL=https://dinum.evalandgo.com/s/index.php?id=JTk4ciU5Mm0lOTclQjE=&a=JTk2byU5NmglOUUlQUI=` pour continuer à afficher le sondage qui était présent jusqu'alors.

fixes #12