### PR TITLE
Erreurs 400 personnalisées

### DIFF
--- a/web/flaskr/__init__.py
+++ b/web/flaskr/__init__.py
@@ -84,6 +84,26 @@ def setup_jinja(app):
         }
 
 
+def setup_error_pages(app):
+    from flask import render_template
+
+    @app.errorhandler(400)
+    def bad_request(error):
+        return render_template("errors/400.html", error=error), 400
+
+    @app.errorhandler(403)
+    def not_authorized(error):
+        return render_template("errors/403.html", error=error), 403
+
+    @app.errorhandler(404)
+    def not_found(error):
+        return render_template("errors/404.html", error=error), 404
+
+    @app.errorhandler(500)
+    def internal_error(error):
+        return render_template("errors/500.html", error=error), 500
+
+
 def create_app(test_config=None, gunicorn_logging=False):
     # create and configure the app
     app = Flask(__name__, instance_relative_config=True)
@@ -93,6 +113,7 @@ def create_app(test_config=None, gunicorn_logging=False):
     setup_csrf(app)
     setup_database(app)
     setup_jinja(app)
+    setup_error_pages(app)
 
     # ensure the instance folder exists
     os.makedirs(app.instance_path, exist_ok=True)

--- a/web/flaskr/routes.py
+++ b/web/flaskr/routes.py
@@ -1544,33 +1544,3 @@ def delete_video_meeting():
 @auth.oidc_logout
 def logout():
     return redirect(url_for("routes.index"))
-
-
-@current_app.errorhandler(403)
-def page_not_authorized(e):
-    return (
-        render_template(
-            "errors/403.html",
-        ),
-        403,
-    )
-
-
-@current_app.errorhandler(404)
-def page_not_found(e):
-    return (
-        render_template(
-            "errors/404.html",
-        ),
-        404,
-    )
-
-
-@current_app.errorhandler(500)
-def page_error(e):
-    return (
-        render_template(
-            "errors/500.html",
-        ),
-        500,
-    )

--- a/web/flaskr/templates/errors/400.html
+++ b/web/flaskr/templates/errors/400.html
@@ -1,0 +1,18 @@
+{% extends 'layout.html' %}
+
+{% block main %}
+<div class="fr-container">
+    <div class="fr-grid-row fr-grid-row--center">
+      <div class="fr-col-md-6">
+        <h1 class="fr-h2">{% trans %}Erreur 400{% endtrans %}</h1>
+        <p>
+        {% if error %}
+            {{ error }}
+        {% else %}
+            {% trans %}La requête que vous avez effectué est invalide. Vous pouvez <a href="/">retourner à l’accueil</a>.{% endtrans %}
+        {% endif %}
+        </p>
+      </div>
+    </div>
+</div>
+{% endblock %}

--- a/web/tests/test_default.py
+++ b/web/tests/test_default.py
@@ -1,4 +1,38 @@
+from flask import abort
 from flask import url_for
+
+
+def test_custom_400(client_app):
+    @client_app.app.route("/custom_400")
+    def custom_400():
+        abort(400, "custom error message")
+
+    response = client_app.get("/custom_400", status=400)
+    response.mustcontain("Erreur 400")
+    response.mustcontain("custom error message")
+
+
+def test_custom_404(client_app):
+    response = client_app.get("/invalid-url", status=404)
+    response.mustcontain("Erreur 404")
+
+
+def test_custom_403(client_app):
+    @client_app.app.route("/custom_403")
+    def custom_403():
+        abort(403)
+
+    response = client_app.get("/custom_403", status=403)
+    response.mustcontain("Erreur 403")
+
+
+def test_custom_500(client_app):
+    @client_app.app.route("/custom_500")
+    def custom_500():
+        abort(500)
+
+    response = client_app.get("/custom_500", status=500)
+    response.mustcontain("Erreur 500")
 
 
 def test_root__anonymous_user(client_app):


### PR DESCRIPTION
Cette PR ne règle pas les erreurs CSRF évoquées en #27, mais permet à minima d'afficher un message d'erreur moins austère lorsqu'elles sont rencontrées.

![Screenshot 2023-10-11 at 17-37-02 Screenshot](https://github.com/numerique-gouv/b3desk/assets/60163/47ba1749-c6c2-45b5-a321-49e8d26b6d0a)

Le message d'erreur est généré par la bibliothèque flask-wtf et n'est pas traduit en français pour le moment, mais j'ai ouvert [un rapport de bug à ce sujet](https://github.com/wtforms/flask-wtf/issues/583).