### PR TITLE
Utilisation de la méthode `url_for` dans les templates

### DIFF
--- a/web/flaskr/templates/brand.html
+++ b/web/flaskr/templates/brand.html
@@ -13,7 +13,7 @@
       </div>
   </div>
   <div class="fr-header__service">
-      <a href="/" title="Accueil - {{ service_title }} - République Française">
+      <a href="{{ url_for("routes.index") }}" title="Accueil - {{ service_title }} - République Française">
         <!-- Webinaire de l'État -->
         <p class="fr-header__service-title">
             {% trans %}{{ service_title }}{% endtrans %}

--- a/web/flaskr/templates/errors/400.html
+++ b/web/flaskr/templates/errors/400.html
@@ -9,7 +9,7 @@
         {% if error %}
             {{ error }}
         {% else %}
-            {% trans %}La requête que vous avez effectué est invalide. Vous pouvez <a href="/">retourner à l’accueil</a>.{% endtrans %}
+        {% trans index_url=url_for("routes.index") %}La requête que vous avez effectué est invalide. Vous pouvez <a href="{{ index_url }}">retourner à l’accueil</a>.{% endtrans %}
         {% endif %}
         </p>
       </div>

--- a/web/flaskr/templates/errors/403.html
+++ b/web/flaskr/templates/errors/403.html
@@ -5,7 +5,7 @@
   <div class="fr-grid-row fr-grid-row--center">
     <div class="fr-col-md-6">
       <h1 class="fr-h2">{% trans %}Erreur 403{% endtrans %}</h1>
-      <p>{% trans %}Vous n’êtes pas autorisé à accéder cette page. Vous pouvez <a href="/">retourner à l’accueil</a>.{% endtrans %}</p>
+      <p>{% trans index_url=url_for("routes.index") %}Vous n’êtes pas autorisé à accéder cette page. Vous pouvez <a href="{{ index_url }}">retourner à l’accueil</a>.{% endtrans %}</p>
     </div>
   </div>
 </div>

--- a/web/flaskr/templates/errors/404.html
+++ b/web/flaskr/templates/errors/404.html
@@ -5,7 +5,7 @@
     <div class="fr-grid-row fr-grid-row--center">
       <div class="fr-col-md-6">
         <h1 class="fr-h2">{% trans %}Erreur 404{% endtrans %}</h1>
-        <p>{% trans %}Cette page n'existe pas. Vous pouvez <a href="/">retourner à l’accueil</a>.{% endtrans %}</p>
+        <p>{% trans index_url=url_for("routes.index") %}Cette page n'existe pas. Vous pouvez <a href="{{ index_url }}">retourner à l’accueil</a>.{% endtrans %}</p>
       </div>
     </div>
 </div>

--- a/web/flaskr/templates/footer.html
+++ b/web/flaskr/templates/footer.html
@@ -35,16 +35,16 @@
         <div class="fr-footer__bottom">
             <ul class="fr-footer__bottom-list">
                 <li class="fr-footer__bottom-item">
-                    <a class="fr-footer__bottom-link" href="/accessibilite">{% trans %}Accessibilité : non conforme{% endtrans %}</a>
+                    <a class="fr-footer__bottom-link" href="{{ url_for("routes.accessibilite") }}">{% trans %}Accessibilité : non conforme{% endtrans %}</a>
                 </li>
                 <li class="fr-footer__bottom-item">
-                    <a class="fr-footer__bottom-link" href="/mentions_legales">{% trans %}Mentions légales{% endtrans %}</a>
+                    <a class="fr-footer__bottom-link" href="{{ url_for("routes.mentions_legales") }}">{% trans %}Mentions légales{% endtrans %}</a>
                 </li>
                 <li class="fr-footer__bottom-item">
-                    <a class="fr-footer__bottom-link" href="/donnees_personnelles">{% trans %}Données personnelles et cookies{% endtrans %}</a>
+                    <a class="fr-footer__bottom-link" href="{{ url_for("routes.donnees_personnelles") }}">{% trans %}Données personnelles et cookies{% endtrans %}</a>
                 </li>
                 <li class="fr-footer__bottom-item">
-                    <a class="fr-footer__bottom-link" href="/cgu">{% trans %}Conditions générales d’utilisation{% endtrans %}</a>
+                    <a class="fr-footer__bottom-link" href="{{ url_for("routes.cgu") }}">{% trans %}Conditions générales d’utilisation{% endtrans %}</a>
                 </li>
             </ul>
         </div>

--- a/web/flaskr/templates/footer/documentation.html
+++ b/web/flaskr/templates/footer/documentation.html
@@ -6,25 +6,25 @@
  {% if documentation_page_subtitle %}
   <p>{{ documentation_page_subtitle }}</p>
   {% endif %}
- <li><a href="/static/misc/PresentationNouveautes2-4.pdf" title="Présentation des nouveautés de la v2.4" target="_blank" rel="noopener noreferrer"> {% trans %}Présentation des nouveautés de la v2.4{% endtrans %}</a></li>
+ <li><a href="{{ url_for('static', filename='misc/PresentationNouveautes2-4.pdf') }}" title="Présentation des nouveautés de la v2.4" target="_blank" rel="noopener noreferrer"> {% trans %}Présentation des nouveautés de la v2.4{% endtrans %}</a></li>
  <br>
  <iframe src="https://podeduc.apps.education.fr/video/0089-big-blue-button-24-les-nouveautes/?is_iframe=true" width="640" height="360" style="padding: 0; margin: 0; border:0"
     sandbox="allow-scripts allow-same-origin" allowfullscreen></iframe>
  <br>
- <li><a href="/static/misc/1.Creer_une_reunion_Improvisee.pdf" title="Créer {{ a_meeting }} improvisée" target="_blank" rel="noopener noreferrer"> {% trans %}Créer {{ an_improvised_meeting }}{% endtrans %}</a></li>
- <li><a href="/static/misc/2.Participer_a_une_reunion.pdf" title="Participer à {{ a_meeting }}" target="_blank" rel="noopener noreferrer"> {% trans %}Participer à {{ a_meeting }}{% endtrans %} </a></li>
- <li><a href="/static/misc/3.Creer_et_parametrer_une_salle_de_reunion.pdf" title="Créer et parametrer une salle de {{ a_meeting }}" target="_blank" rel="noopener noreferrer"> {% trans %}Créer et paramétrer une salle de {{ meeting_label }}{% endtrans %} </a></li>
- <li><a href="/static/misc/4.Activer_le_materiel_dans_le_navigateur.pdf" title="Activer le matériel dans le navigateur" target="_blank" rel="noopener noreferrer"> {% trans %}Activer le matériel dans le navigateur{% endtrans %} </a></li>
- <li><a href="/static/misc/5.G%C3%A9rer_les_participants.pdf" title="Gérer_les_utilisateurs" target="_blank" rel="noopener noreferrer"> {% trans %}Gérer les utilisateurs{% endtrans %} </a></li>
- <li><a href="/static/misc/6.G%C3%A9rer_les_documents.pdf" title="Gérer les documents" target="_blank" rel="noopener noreferrer"> {% trans %}Gérer les documents{% endtrans %} </a></li>
- <li><a href="/static/misc/7.Creer_des_r%C3%A9unions_priv%C3%A9es.pdf" title="Gestion des {{ private_meetings }}" target="_blank" rel="noopener noreferrer"> {% trans %}Gestion des {{ private_meetings }}{% endtrans %} </a></li>
- <li><a href="/static/misc/8.D%C3%A9l%C3%A9guer_la_cr%C3%A9ation_de_r%C3%A9union.pdf" title="Déléguer la création de {{ meeting_label }}" target="_blank" rel="noopener noreferrer"> {% trans %}Déléguer la création de {{ meeting_label }}{% endtrans %} </a></li>
- <li><a href="/static/misc/9.Enregistrer_une_r%C3%A9union.pdf" title="Enregistrer {{ a_meeting }}" target="_blank" rel="noopener noreferrer"> {% trans %}Enregistrer {{ a_meeting }}{% endtrans %} </a></li>
- <li><a href="/static/misc/10.Cr%C3%A9er_un_Sondage.pdf" title="Créer un sondage" target="_blank" rel="noopener noreferrer"> {% trans %}Créer un sondage{% endtrans %} </a></li>
- <li><a href="/static/misc/11.Joindre_une_reunion_par_telephone.pdf" title="Joindre {{ a_meeting }} par téléphone" target="_blank" rel="noopener noreferrer"> {% trans %}Joindre {{ a_meeting }} par téléphone{% endtrans %}</a></li>
- <li><a href="/static/misc/12.Afficher_le_tableau_de_bord_activite_participants.pdf" title="Afficher le tableau de bord" target="_blank" rel="noopener noreferrer"> {% trans %}Afficher le tableau de bord{% endtrans %}</a></li>
- <li><a href="/static/misc/13.G%C3%A9rer_la_mise_en_page.pdf" title="Gérer la mise en page" target="_blank" rel="noopener noreferrer"> {% trans %}Gérer la mise en page{% endtrans %}</a></li>
- <li><a href="/static/misc/14.PluginControleVolume.pdf" title="Extension contrôle du volume" target="_blank" rel="noopener noreferrer"> {% trans %}Contrôle du volume{% endtrans %}</a></li>
+ <li><a href="{{ url_for('static', filename='misc/1.Creer_une_reunion_Improvisee.pdf') }}" title="Créer {{ a_meeting }} improvisée" target="_blank" rel="noopener noreferrer"> {% trans %}Créer {{ an_improvised_meeting }}{% endtrans %}</a></li>
+ <li><a href="{{ url_for('static', filename='misc/2.Participer_a_une_reunion.pdf') }}" title="Participer à {{ a_meeting }}" target="_blank" rel="noopener noreferrer"> {% trans %}Participer à {{ a_meeting }}{% endtrans %} </a></li>
+ <li><a href="{{ url_for('static', filename='misc/3.Creer_et_parametrer_une_salle_de_reunion.pdf') }}" title="Créer et parametrer une salle de {{ a_meeting }}" target="_blank" rel="noopener noreferrer"> {% trans %}Créer et paramétrer une salle de {{ meeting_label }}{% endtrans %} </a></li>
+ <li><a href="{{ url_for('static', filename='misc/4.Activer_le_materiel_dans_le_navigateur.pdf') }}" title="Activer le matériel dans le navigateur" target="_blank" rel="noopener noreferrer"> {% trans %}Activer le matériel dans le navigateur{% endtrans %} </a></li>
+ <li><a href="{{ url_for('static', filename='misc/5.G%C3%A9rer_les_participants.pdf') }}" title="Gérer_les_utilisateurs" target="_blank" rel="noopener noreferrer"> {% trans %}Gérer les utilisateurs{% endtrans %} </a></li>
+ <li><a href="{{ url_for('static', filename='misc/6.G%C3%A9rer_les_documents.pdf') }}" title="Gérer les documents" target="_blank" rel="noopener noreferrer"> {% trans %}Gérer les documents{% endtrans %} </a></li>
+ <li><a href="{{ url_for('static', filename='misc/7.Creer_des_r%C3%A9unions_priv%C3%A9es.pdf') }}" title="Gestion des {{ private_meetings }}" target="_blank" rel="noopener noreferrer"> {% trans %}Gestion des {{ private_meetings }}{% endtrans %} </a></li>
+ <li><a href="{{ url_for('static', filename='misc/8.D%C3%A9l%C3%A9guer_la_cr%C3%A9ation_de_r%C3%A9union.pdf') }}" title="Déléguer la création de {{ meeting_label }}" target="_blank" rel="noopener noreferrer"> {% trans %}Déléguer la création de {{ meeting_label }}{% endtrans %} </a></li>
+ <li><a href="{{ url_for('static', filename='misc/9.Enregistrer_une_r%C3%A9union.pdf') }}" title="Enregistrer {{ a_meeting }}" target="_blank" rel="noopener noreferrer"> {% trans %}Enregistrer {{ a_meeting }}{% endtrans %} </a></li>
+ <li><a href="{{ url_for('static', filename='misc/10.Cr%C3%A9er_un_Sondage.pdf') }}" title="Créer un sondage" target="_blank" rel="noopener noreferrer"> {% trans %}Créer un sondage{% endtrans %} </a></li>
+ <li><a href="{{ url_for('static', filename='misc/11.Joindre_une_reunion_par_telephone.pdf') }}" title="Joindre {{ a_meeting }} par téléphone" target="_blank" rel="noopener noreferrer"> {% trans %}Joindre {{ a_meeting }} par téléphone{% endtrans %}</a></li>
+ <li><a href="{{ url_for('static', filename='misc/12.Afficher_le_tableau_de_bord_activite_participants.pdf') }}" title="Afficher le tableau de bord" target="_blank" rel="noopener noreferrer"> {% trans %}Afficher le tableau de bord{% endtrans %}</a></li>
+ <li><a href="{{ url_for('static', filename='misc/13.G%C3%A9rer_la_mise_en_page.pdf') }}" title="Gérer la mise en page" target="_blank" rel="noopener noreferrer"> {% trans %}Gérer la mise en page{% endtrans %}</a></li>
+ <li><a href="{{ url_for('static', filename='misc/14.PluginControleVolume.pdf') }}" title="Extension contrôle du volume" target="_blank" rel="noopener noreferrer"> {% trans %}Contrôle du volume{% endtrans %}</a></li>
  <br>
  <style class="fr-mb-4w">
       table, th, td {
@@ -82,8 +82,8 @@ Ces ports sont :
 
 <h3>Fichiers avec les IP et FQDN des serveurs BBB</h3>
 <ul>
- <li><a href="/static/misc/ip-fqdn-adm-sort.txt" title="Liste des serveurs BigBlueButton pour l'Éducation" target="_blank" rel="noopener noreferrer"> Visio Éducation</a></li>
- <li><a href="/static/misc/ip-fqdn-bbb-dinum-sort.txt" title="Liste des serveurs BigBlueButton pour le Webinaire de l'État" target="_blank" rel="noopener noreferrer"> Webinaire </a></li>
- <li><a href="/static/misc/ip-fqdn-bbb-complet.txt" title="Liste des serveurs BigBlueButton pour l'ensemble des BigBlueBlutton" target="_blank" rel="noopener noreferrer"> Tous </a></li>
+ <li><a href="{{ url_for('static', filename='misc/ip-fqdn-adm-sort.txt') }}" title="Liste des serveurs BigBlueButton pour l'Éducation" target="_blank" rel="noopener noreferrer"> Visio Éducation</a></li>
+ <li><a href="{{ url_for('static', filename='misc/ip-fqdn-bbb-dinum-sort.txt') }}" title="Liste des serveurs BigBlueButton pour le Webinaire de l'État" target="_blank" rel="noopener noreferrer"> Webinaire </a></li>
+ <li><a href="{{ url_for('static', filename='misc/ip-fqdn-bbb-complet.txt') }}" title="Liste des serveurs BigBlueButton pour l'ensemble des BigBlueBlutton" target="_blank" rel="noopener noreferrer"> Tous </a></li>
 </ul>
 {% endblock %}

--- a/web/flaskr/templates/jumbotron.html
+++ b/web/flaskr/templates/jumbotron.html
@@ -41,7 +41,7 @@
         <div class="fr-col-md-6">
           <h1 class="fr-text--lead fr-text--bold">{% trans %}Vous organisez régulièrement des {{ some_meetings }}{% endtrans %}</h1>
           <p class="fr-text">{% trans %}Vous êtes agent de l’État, créez un compte pour organiser et conserver vos {{ some_meetings }}.{% endtrans %}</p>
-          <p><a class="fr-btn" target="_blank" rel="noopener" href="/welcome">{% trans %}Se connecter ou créer un compte{% endtrans %}</a></p>
+          <p><a class="fr-btn" target="_blank" rel="noopener" href="{{ url_for("routes.welcome") }}">{% trans %}Se connecter ou créer un compte{% endtrans %}</a></p>
           <p></p>
           {% if stats %}
             <p>

--- a/web/flaskr/templates/meeting/files.html
+++ b/web/flaskr/templates/meeting/files.html
@@ -33,16 +33,16 @@
 {% endmacro %}
 
     <link rel="stylesheet"
-     href="/static/js/dropzone.css"/>
+    href="{{ url_for('static', filename='js/dropzone.css') }}"/>
 
     <script type="application/javascript"
-     src="/static/js/dropzone-min.js">
+        src="{{ url_for('static', filename='js/dropzone-min.js') }}">
     </script>
 
 <h1 class="fr-h2">Gestion des {{ meeting_presentation }}s associées à <em>{{meeting.name }}</em></h1>
 
 <div class="fr-mt-4w fr-mb-4w">
-  <a href="/welcome"><span aria-hidden="true" class="fr-fi-arrow-left-line"></span>Retour à mes {{ meeting_label }}s</a>
+    <a href="{{ url_for("routes.welcome") }}"><span aria-hidden="true" class="fr-fi-arrow-left-line"></span>Retour à mes {{ meeting_label }}s</a>
 </div>
 
 <div id="messageHolder">
@@ -217,7 +217,7 @@
 <div class="fr-grid-row fr-grid-row--center fr-grid-row--gutters fr-mt-4w">
   <div class="fr-col-sm-10 fr-col-lg-9">
     <div class="fr-mt-4w">
-      <a href="/welcome"><span aria-hidden="true" class="fr-fi-arrow-left-line"></span>Retour à mes {{ meeting_label }}s</a>
+        <a href="{{ url_for("routes.welcome") }}"><span aria-hidden="true" class="fr-fi-arrow-left-line"></span>Retour à mes {{ meeting_label }}s</a>
     </div>
   </div>
 </div>

--- a/web/flaskr/templates/meeting/jumbotron.html
+++ b/web/flaskr/templates/meeting/jumbotron.html
@@ -4,7 +4,7 @@
   {% else %}
     <h4 class="fr-callout__title">{% trans %}Nouveau webinaire{% endtrans %}</h4>
   {% endif %}
-  <a class="fr-btn" title="Retour au tableau de bord" href="/welcome">
+  <a class="fr-btn" title="Retour au tableau de bord" href="{{ url_for("routes.welcome") }}">
     {% trans %}Retour au tableau de bord{% endtrans %}
   </a>
 </div>

--- a/web/flaskr/templates/meeting/list.html
+++ b/web/flaskr/templates/meeting/list.html
@@ -1,7 +1,7 @@
 <div class="list-meeting-rooms">
   <h2>{% trans %}Mes salles de {{ some_meetings }}{% endtrans %}</h2>
   {% if can_create_meetings == true %}
-  <p class="fr-text--sm"><a href="/meeting/new" ><span aria-hidden="true" class="ri-add-line"></span> {% trans %}Créer une salle de {{ meeting_label }}</a> vous permet de conserver les réglages et le lien de la salle.{% endtrans %}</p>
+  <p class="fr-text--sm"><a href="{{ url_for("routes.new_meeting") }}" ><span aria-hidden="true" class="ri-add-line"></span> {% trans %}Créer une salle de {{ meeting_label }}</a> vous permet de conserver les réglages et le lien de la salle.{% endtrans %}</p>
   {% else %}
   <div class="fr-highlight error">
     <p class="">

--- a/web/flaskr/templates/meeting/recordings.html
+++ b/web/flaskr/templates/meeting/recordings.html
@@ -6,7 +6,7 @@
 {% block main %}
 <h1 class="fr-h2">{% trans meeting_name=meeting.name %}Enregistrements de <em>{{meeting_name }}{% endtrans %}</em></h1>
 <div class="fr-mt-4w">
-    <a href="/welcome"><span aria-hidden="true" class="fr-fi-arrow-left-line"></span>{% trans %}Retour à mes {{ meeting_label }}s{% endtrans %}</a>
+    <a href="{{ url_for("routes.welcome") }}"><span aria-hidden="true" class="fr-fi-arrow-left-line"></span>{% trans %}Retour à mes {{ meeting_label }}s{% endtrans %}</a>
 </div>
 <div class="recording-list">
     {% if meeting.running %}
@@ -118,7 +118,7 @@
     {% endfor %}
     </div>
     <div class="fr-mt-4w">
-        <a href="/welcome"><span aria-hidden="true" class="fr-fi-arrow-left-line"></span>Retour à mes {{ meeting_label }}s</a>
+        <a href="{{ url_for("routes.welcome") }}"><span aria-hidden="true" class="fr-fi-arrow-left-line"></span>Retour à mes {{ meeting_label }}s</a>
     </div>
 {% endblock %}
 

--- a/web/flaskr/templates/meeting/submit.html
+++ b/web/flaskr/templates/meeting/submit.html
@@ -4,5 +4,5 @@
 {% else %}
   <button type="submit" class="fr-btn">{% trans %}Créer{% endtrans %}</button>
 {% endif %}
-  <a class="fr-btn fr-btn--secondary" href="/welcome">{% trans %}Annuler{% endtrans %}</a>
+<a class="fr-btn fr-btn--secondary" href="{{ url_for("routes.welcome") }}">{% trans %}Annuler{% endtrans %}</a>
 </div>

--- a/web/flaskr/templates/redirections.html
+++ b/web/flaskr/templates/redirections.html
@@ -1,7 +1,7 @@
 <div class="fr-grid-row fr-mt-4w">
   <div class="fr-col-md-6">
     <form action="/direct">
-      <a href="/welcome" class="fr-btn fr-btn--lg">{% trans %}Connectez-vous ou créez un compte{% endtrans %}</a>
+        <a href="{{ url_for("routes.welcome") }}" class="fr-btn fr-btn--lg">{% trans %}Connectez-vous ou créez un compte{% endtrans %}</a>
     </form>
   </div>
 </div>

--- a/web/flaskr/templates/rie.html
+++ b/web/flaskr/templates/rie.html
@@ -2,6 +2,6 @@
 <div class="fr-highlight info fr-mt-2w fr-mb-2w"" role="alert">
     {% trans %}Service accessible suivant les politiques de sécurité de votre ministère.{% endtrans %}
     {% trans %}Si l'audio ou la vidéo ne fonctionne pas, vous devez utiliser un autre appareil (ordinateur, smartphone).{% endtrans %}
-<br><small><a href="/faq">{% trans %}en savoir plus{% endtrans %}</a></small>
+    <br><small><a href="{{ url_for("routes.faq") }}">{% trans %}en savoir plus{% endtrans %}</a></small>
 </div>
 {% endif %}

--- a/web/flaskr/templates/tools.html
+++ b/web/flaskr/templates/tools.html
@@ -8,7 +8,7 @@
       </li>
 
       <li>
-        <a class="fr-btn" href="/faq">
+          <a class="fr-btn" href="{{ url_for("routes.faq") }}">
           <span aria-hidden="true" class="ri-information-line fr-mr-1w"></span>
           {% trans %}Modalités d'accès{% endtrans %}
         </a>
@@ -26,7 +26,7 @@
         </li>
         {% endif %} -->
         <li>
-          <a class="fr-btn" href="/logout">
+            <a class="fr-btn" href="{{ url_for("routes.logout") }}">
             <div>
               <span aria-hidden="true" class="ri-account-circle-line fr-mr-1w"></span>{{ user.fullname }}
               <br><small>{% trans %}se déconnecter{% endtrans %}</small>
@@ -35,7 +35,7 @@
         </li>
       {% else %}
         <li>
-          <a class="fr-btn" href="/welcome">
+            <a class="fr-btn" href="{{ url_for("routes.welcome") }}">
             <span aria-hidden="true" class="ri-account-circle-line fr-mr-1w"></span>
             {% trans %}S’identifier{% endtrans %}
           </a>


### PR DESCRIPTION
Cette PR réusine les URLs dans les templates pour utiliser les méthodes préconisées par Flask/jinja. Cela permet d'être alerté en cas d'erreur dans les écritures des urls notamment.

fixes #33