### PR TITLE
Intégration du code matomo

### DIFF
--- a/web.env.example
+++ b/web.env.example
@@ -83,3 +83,6 @@ REDIS_URL=broker:6379  # SHARED between worker and web services, used for backgr
 
 # Feature flags
 FILE_SHARING=on
+
+MATOMO_URL=
+MATOMO_SITE_ID=

--- a/web/b3desk/settings.py
+++ b/web/b3desk/settings.py
@@ -1042,3 +1042,13 @@ class MainSettings(BaseSettings):
     Passé à l'API BBB via le paramètre ``meta_analytics-callback-url``.
     Plus d’informations sur https://docs.bigbluebutton.org/development/api/#create
     """
+
+    MATOMO_URL: Optional[str] = None
+    """
+    URL de l’instance de Matomo vers laquelle envoyer des statistiques.
+    """
+
+    MATOMO_SITE_ID: Optional[str] = None
+    """
+    ID de l’instance B3Desk dans Matomo.
+    """

--- a/web/b3desk/templates/layout.html
+++ b/web/b3desk/templates/layout.html
@@ -64,6 +64,21 @@
     <script type="text/javascript" nomodule href="dsfr-1.7/dsfr/dsfr.nomodule.min.js" ></script>
     <!-- Scampi Modal en attendant la modale GouvFr-->
     <script src="{{ url_for('static', filename='js/scampi-modal.js')}}"></script>
+    {% if config.get("MATOMO_SITE_ID") and config.get("MATOMO_URL") %}
+    <script>
+      var _paq = window._paq = window._paq || [];
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="{{ config.get("MATOMO_URL") }}";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', '{{ config.get("MATOMO_SITE_ID") }}']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    {% endif %}
     {% block js %}{% endblock %}
   </div>
   </body>

--- a/web/b3desk/templates/static-layout.html
+++ b/web/b3desk/templates/static-layout.html
@@ -41,6 +41,21 @@
     <script src="{{ url_for('static', filename='js/scampi-modal.js')}}"></script>
     <!-- minified nc filepicker : from https://github.com/julien-nc/nextcloud-webdav-filepicker -->
     <!-- <script src="{{ url_for('static', filename='js/filePickerWrapper.js')}}"></script> -->
+    {% if config.get("MATOMO_SITE_ID") and config.get("MATOMO_URL") %}
+    <script>
+      var _paq = window._paq = window._paq || [];
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="{{ config.get("MATOMO_URL") }}";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 'config.get("MATOMO_SITE_ID")']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    {% endif %}
     {% block js %}{% endblock %}
   </div>
   </body>


### PR DESCRIPTION
Cette PR définit deux nouvelles variables de configuration `MATOMO_URL` et `MATOMO_SITE_ID` qui,  si elles sont définies toutes les deux, insèrent le code de matomo dans toutes les pages du site.

fixes #54