### PR TITLE
Force secure protocole for nextcloud token according to new env var

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,10 @@ extend-exclude = '''
 
 [tool.pytest.ini_options]
 testpaths = "web"
+markers = [
+    "secure: cloud auth responds with a https url",
+    "no_scheme: cloud auth responds without any scheme for url",
+]
 
 [tool.ruff]
 ignore = [

--- a/web.env.example
+++ b/web.env.example
@@ -75,6 +75,7 @@ TMP_DOWNLOAD_DIR=/tmp/download/  # used when retrieving files from remote Nextcl
 MAX_SIZE_UPLOAD=20000000
 TIME_FORMAT=%Y-%m-%d
 UPLOAD_DIR=/tmp/b3desk/  # used by dropzone to upload files
+FORCE_HTTPS_ON_EXTERNAL_URLS=off
 NC_LOGIN_API_URL=http://tokenmock:80/index.php  # nextcloud token provider endpoint (currently pointing toward related service in docker network)
 NC_LOGIN_API_KEY=MY-TOTALLY-COOL-API-KEY  # SHARED between web and tokenmock services as nextcloud credentials
 NEXTCLOUD_SESSIONTOKEN_KEY=megatokengeneratedatleast64long  # SHARED between nextcloud (sessiontoken app) and tokenmock services

--- a/web/b3desk/settings.py
+++ b/web/b3desk/settings.py
@@ -136,6 +136,11 @@ class MainSettings(BaseSettings):
     NC_LOGIN_API_KEY: Optional[str] = None
     """Clé d'API Nextcloud."""
 
+    FORCE_HTTPS_ON_EXTERNAL_URLS: bool = False
+    """
+    Force le protocole https pour les URLs Nextcloud.
+    """
+
     UPLOAD_DIR: str
     """Chemin vers le dossier dans lequel seront stockés les fichiers
     téléversés par les utilisateurs."""

--- a/web/tests/test_user.py
+++ b/web/tests/test_user.py
@@ -1,7 +1,9 @@
 from datetime import date
 
+import pytest
 from b3desk.models import db
 from b3desk.models.users import get_or_create_user
+from b3desk.models.users import make_nextcloud_credentials_request
 from b3desk.models.users import User
 from freezegun import freeze_time
 
@@ -39,3 +41,69 @@ def test_update_last_connection_if_more_than_24h(client_app):
         get_or_create_user(user_info)
 
         assert user.last_connection_utc_datetime.date() == date(2021, 8, 11)
+
+
+def test_make_nextcloud_credentials_request_with_scheme_response(
+    client_app, app, cloud_service_response, mocker
+):
+    assert cloud_service_response.data["nclocator"].startswith("http://")
+    mocker.patch(
+        "b3desk.models.users.requests.post", return_value=cloud_service_response
+    )
+    app.config["FORCE_HTTPS_ON_EXTERNAL_URLS"] = False
+    credentials = make_nextcloud_credentials_request(
+        url=app.config["NC_LOGIN_API_URL"],
+        payload={"username": "Alice"},
+        headers={"X-API-KEY": app.config["NC_LOGIN_API_KEY"]},
+    )
+    assert credentials["nclocator"].startswith("http://")
+
+
+@pytest.mark.secure
+def test_make_nextcloud_credentials_request_with_secure_response(
+    client_app, app, cloud_service_response, mocker
+):
+    assert cloud_service_response.data["nclocator"].startswith("https://")
+    mocker.patch(
+        "b3desk.models.users.requests.post", return_value=cloud_service_response
+    )
+    app.config["FORCE_HTTPS_ON_EXTERNAL_URLS"] = False
+    credentials = make_nextcloud_credentials_request(
+        url=app.config["NC_LOGIN_API_URL"],
+        payload={"username": "Alice"},
+        headers={"X-API-KEY": app.config["NC_LOGIN_API_KEY"]},
+    )
+    assert credentials["nclocator"].startswith("https://")
+
+
+def test_make_nextcloud_credentials_request_force_secure_for_unsecure(
+    client_app, app, cloud_service_response, mocker
+):
+    assert cloud_service_response.data["nclocator"].startswith("http://")
+    mocker.patch(
+        "b3desk.models.users.requests.post", return_value=cloud_service_response
+    )
+    app.config["FORCE_HTTPS_ON_EXTERNAL_URLS"] = True
+    credentials = make_nextcloud_credentials_request(
+        url=app.config["NC_LOGIN_API_URL"],
+        payload={"username": "Alice"},
+        headers={"X-API-KEY": app.config["NC_LOGIN_API_KEY"]},
+    )
+    assert credentials["nclocator"].startswith("https://")
+
+
+@pytest.mark.no_scheme
+def test_make_nextcloud_credentials_request_force_secure_for_missing_scheme(
+    client_app, app, cloud_service_response, mocker
+):
+    assert not cloud_service_response.data["nclocator"].startswith("http")
+    mocker.patch(
+        "b3desk.models.users.requests.post", return_value=cloud_service_response
+    )
+    app.config["FORCE_HTTPS_ON_EXTERNAL_URLS"] = True
+    credentials = make_nextcloud_credentials_request(
+        url=app.config["NC_LOGIN_API_URL"],
+        payload={"username": "Alice"},
+        headers={"X-API-KEY": app.config["NC_LOGIN_API_KEY"]},
+    )
+    assert credentials["nclocator"].startswith("https://")


### PR DESCRIPTION
Oblige l'utilisation de https si précisé dans la configuration.

Il y a une nouvelle variable `FORCE_HTTPS_ON_EXTERNAL_URLS` (par défaut à False) à ajouter dans la conf (voir web.env.example)

fixes #48 