### PR TITLE
La balise HTML `<title>` est lue depuis la configuration sur toutes les pages

### DIFF
--- a/web/b3desk/routes.py
+++ b/web/b3desk/routes.py
@@ -321,7 +321,6 @@ def welcome():
     stats = get_meetings_stats()
     return render_template(
         "welcome.html",
-        title=current_app.config["TITLE"],
         stats=stats,
         max_participants=current_app.config["MAX_PARTICIPANTS"],
         meetings=[

--- a/web/b3desk/templates/layout.html
+++ b/web/b3desk/templates/layout.html
@@ -7,7 +7,7 @@
     <meta name="author" content="">
     <link rel="icon" href="{{ url_for('static', filename='images/favicon.png') }}">
 
-    <title>{{title}}</title>
+    <title>{{ config["TITLE"] }}</title>
 
     <!-- DSFR core CSS -->
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/global.css') }}">

--- a/web/b3desk/templates/static-layout.html
+++ b/web/b3desk/templates/static-layout.html
@@ -7,7 +7,7 @@
     <meta name="author" content="">
     <link rel="icon" href="{{ url_for('static', filename='images/favicon.png') }}">
 
-    <title>{{title}}</title>
+    <title>{{ config["TITLE"] }}</title>
 
     <!-- DSFR core CSS -->
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/global.css') }}">


### PR DESCRIPTION
Avant cela, seule la page d'accueil avait un titre de page (la balise HTML `<title>`) correctement lu depuis la configuration.

fixes #62