### PR TITLE
Utilisation de `diff-cover` dans le job de couverture de code de GHA

### DIFF
--- a/.github/workflows/Test_coverage.yml
+++ b/.github/workflows/Test_coverage.yml
@@ -18,41 +18,25 @@ jobs:
       - name: Setup git
         uses: actions/checkout@v3
 
+      - name: Get the git branch
+        uses: actions/checkout@v3
+        with:
+          ref: main # TODO: dynamically get the branch against which the PR will be merged?
+
       - name: Setup python
         uses: actions/setup-python@v4
         with:
           python-version: 3.11
 
-      - name: Switch to main branch
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.repository.default_branch }}
-
-      - name: Install previous python dependencies
+      - name: Install python dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r web/requirements.app.txt
           pip install -r web/requirements.dev.txt
+          pip install diff-cover
 
-      - name: Get previous coverage
-        id: get_coverage
-        run: |
-          coverage run -m pytest --envfile web.env.example
-          coverage json
-          export PERCENT_COVERED=$(python -c "import json;print(json.load(open('coverage.json'))['totals']['percent_covered'])")
-          echo "percent_covered=$PERCENT_COVERED" >> $GITHUB_OUTPUT
+      - name: Run unit tests with coverage
+        run: pytest --envfile web.env.example --cov --cov-report=xml
 
-      - name: Switch to branch to merge
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Install new python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r web/requirements.app.txt
-          pip install -r web/requirements.dev.txt
-
-      - name: Check that coverage at least equals to main coverage
-        run: pytest --envfile web.env.example --cov --cov-fail-under=${{ steps.get_coverage.outputs.percent_covered }}
+      - name: Check that the edited lines are all covered
+        run: diff-cover coverage.xml --fail-under=100


### PR DESCRIPTION
Cela change un peu la manière dont on vérifie que le code est bien couvert. Avec cet outil, toute ligne modifiée lors d'une PR doit être couverte par un test, ce qui oblige à avoir une couverture à minima égale sur le code édité.

Par contre, le taux de couverture au global n'est pas vérifié, donc on n'est pas impacté lorsque des réusinages suppriment du code.

fixes #36 