### PR TITLE
Message d'attente pour les modérateurs

### DIFF
--- a/web/b3desk/templates/meeting/wait.html
+++ b/web/b3desk/templates/meeting/wait.html
@@ -18,7 +18,15 @@
         </div>
 
         <p>
-        {% trans %}Votre hôte n’est pas encore arrivé. Vous entrerez automatiquement dans la salle de visio-conférence dès qu’il sera présent.{% endtrans %}
+        {% if role == "moderator" %}
+            {% trans %}
+                La salle de visio-conférence est en cours de création. Vous entrerez automatiquement dans la salle dès qu'elle sera opérationnelle.
+            {% endtrans %}
+        {% else %}
+            {% trans %}
+                Votre hôte n’est pas encore arrivé. Vous entrerez automatiquement dans la salle de visio-conférence dès qu’il sera présent.
+            {% endtrans %}
+        {% endif %}
         </p>
 
         <form id="joinMeetingForm" action="{{ url_for("routes.join_meeting") }}" method="POST">


### PR DESCRIPTION
Parfois les salons mettent du temps à être créés dans BBB et les modérateurs peuvent parfois se retrouver en salle d'attente.

Cette PR corrige le message qui est affiché aux modérateurs en salle d'attente. 

fixes #77