### PR TITLE
Correctif de l'erreur sur les fichiers par défaut de BBB

### DIFF
--- a/web/b3desk/models/meetings.py
+++ b/web/b3desk/models/meetings.py
@@ -123,6 +123,12 @@ class Meeting(db.Model):
         return None
 
     @property
+    def non_default_files(self):
+        return [
+            meeting_file for meeting_file in self.files if not meeting_file.is_default
+        ]
+
+    @property
     def meetingID(self):
         if self.id is not None:
             fid = "meeting-persistent-%i" % (self.id)


### PR DESCRIPTION
Lorsque FILE_SHARING était activé, et qu'aucun fichier n'était attaché à un séminaire, alors le fichier par défaut de BBB n'était pas utilisé.

fixes #111