### PR TITLE
Add modal to copy direct link to recording

### DIFF
--- a/web/b3desk/models/bbb.py
+++ b/web/b3desk/models/bbb.py
@@ -275,9 +275,26 @@ class BBB:
                         type = format.find("type").text
                         if type in ("presentation", "video"):
                             data["playbacks"][type] = {
-                                "url": format.find("url").text,
+                                "url": (media_url := format.find("url").text),
                                 "images": images,
                             }
+                            if type == "video":
+                                try:
+                                    resp = requests.get(
+                                        direct_link := media_url + "video-0.m4v"
+                                    )
+                                    if resp.status_code == 200:
+                                        data["playbacks"][type]["direct_link"] = (
+                                            direct_link
+                                        )
+                                except (
+                                    requests.exceptions.HTTPError,
+                                    requests.exceptions.ConnectionError,
+                                ):
+                                    current_app.logger.warning(
+                                        "No direct recording link for meeting %s",
+                                        self.meeting.meetingID,
+                                    )
                     result.append(data)
             except Exception as exception:
                 current_app.logger.error(exception)

--- a/web/b3desk/settings.py
+++ b/web/b3desk/settings.py
@@ -1051,3 +1051,20 @@ class MainSettings(BaseSettings):
 
     ENABLE_LASUITENUMERIQUE: Optional[bool] = False
     """Enable LaSuite numerique homepage style."""
+
+    VIDEO_STREAMING_LINKS: Optional[dict[str, str]] = {}
+    """List of streaming service for video sharing."""
+
+    @field_validator("VIDEO_STREAMING_LINKS", mode="before")
+    def get_video_streaming_links(
+        cls,
+        video_streaming_links: Optional[dict[str, str]],
+        info: ValidationInfo,
+    ) -> dict[str, str]:
+        if not video_streaming_links:
+            return {}
+
+        if isinstance(video_streaming_links, str):
+            return json.loads(video_streaming_links)
+
+        return video_streaming_links

--- a/web/b3desk/templates/meeting/recordings.html
+++ b/web/b3desk/templates/meeting/recordings.html
@@ -26,10 +26,12 @@
             {% trans %}Renommer l’enregistrement{% endtrans %}
         </button>
     </h3>
+    <span>
         {% trans start_date=recording.start_date|dateformat, expiration_date=(recording.end_date+config["RECORDING_DURATION"])|dateformat %}
         Enregistré le {{ start_date }} -
         Expire le {{ expiration_date }}
         {% endtrans %}
+    </span>
     <div class="fr-table fr-table--bordered fr-table--layout-fixed">
         <table>
             <thead>
@@ -53,18 +55,19 @@
                     </td>
                     <td style="vertical-align: middle">
                         <div class="fr-grid-row fr-grid-row--gutters btn-actions">
-                            <a class="fr-btn fr-btn--primary fr-mx-1w" target="_blank" rel="noopener" href="{{ playback.url }}" title="Voir l'enregistrement"><span class="fr-icon-play-line"></span></a>
-                            <button type="button" class="btn-copy fr-btn fr-btn--primary fr-mx-1w"" id="meeting-{{ meeting.id }}-moderator-copy" onclick="navigator.clipboard.writeText('{{ playback.url }}');" title="Copier le lien de l'enregistrement dans le presse-papiers">
+                            <a class="fr-btn fr-btn--primary" target="_blank" rel="noopener" href="{{ playback.url }}" title="Voir l'enregistrement"><span class="fr-icon-play-line"></span></a>
+                            <button type="button" class="btn-copy fr-btn fr-btn--primary fr-ml-1v" id="meeting-{{ meeting.id }}-moderator-copy" onclick="navigator.clipboard.writeText('{{ playback.url }}');" title="Copier le lien de l'enregistrement dans le presse-papiers">
                                 <span class="fr-icon-clipboard-line"></span>
                             </button>
                             {% if recording.playbacks.get("video") %}
+                            <a class="fr-btn fr-btn--primary fr-ml-2w" target="_blank" rel="noopener" href="{{ recording.playbacks['video'].url }}" title="Voir l'enregistrement mp4"><span class="fr-icon-film-line"></span></a>
                             {% if recording.playbacks.video.get("direct_link") %}
-                            <button class="fr-btn fr-btn--primary fr-mx-1w" data-fr-opened="false" aria-controls="share-video-{{ recording.recordID }}" title="Partager l'enregistrement">
-                                <span class="fr-icon-git-branch-line" aria-hidden="true"></span>
+                            <button class="fr-btn fr-btn--primary fr-ml-1v" data-fr-opened="false" aria-controls="share-video-{{ recording.recordID }}" title="Partager l'enregistrement mp4">
+                                <span class="fr-icon-links-line" aria-hidden="true"></span>
                             </button>
                             {% endif %}
                             {% endif %}
-                            <button class="fr-btn fr-btn--secondary fr-fi-delete-line fr-mx-1w"  data-fr-opened="false" aria-controls="delete-video-{{ recording.recordID }}">
+                            <button class="fr-btn fr-btn--secondary fr-fi-delete-line fr-ml-2w"  data-fr-opened="false" aria-controls="delete-video-{{ recording.recordID }}">
                                 {% trans meeting_name=meeting.name %}Supprimer video de {{ meeting_name }}{% endtrans %}
                             </button>
                         </div>
@@ -171,6 +174,16 @@
                                 <span class="" aria-hidden="true"></span>
                                 Partager l'enregistrement de "<em>{{ recording_name }}</em>"
                             </h1>
+                            <p>
+                                Cet enregistrement est conservé temporairement sur ce service. Pour le mettre à disposition de manière pérenne, fournissez ce lien à des services dédiés à la diffusion
+                                {%- if config["VIDEO_STREAMING_LINKS"] -%}
+                                    {%- for service, link in config["VIDEO_STREAMING_LINKS"].items() -%}
+                                        {{ " tels que " if loop.first else ", " if not loop.last else " ou " }}<a href="{{link}}">{{service}}</a>
+                                    {%- endfor -%}
+                                {%- endif -%}
+                                .
+                                En cas de diffusion publique, veillez préalablement à obtenir l'autorisation des participants.
+                            </p>
                             {% if recording.playbacks.get("video") %}
                             {% if recording.playbacks.video.get("direct_link") %}
                             <div class="fr-grid-row fr-grid-row--center">

--- a/web/b3desk/templates/meeting/recordings.html
+++ b/web/b3desk/templates/meeting/recordings.html
@@ -58,9 +58,13 @@
                                 <span class="fr-icon-clipboard-line"></span>
                             </button>
                             {% if recording.playbacks.get("video") %}
-                            <a class="fr-btn fr-btn--primary fr-mx-1w"" download target="_blank" rel="noopener" href="{{ recording.playbacks['video'].url }}" title="Voir l'enregistrement mp4 (fichier téléchargeable) et le chat">mp4</a>
+                            {% if recording.playbacks.video.get("direct_link") %}
+                            <button class="fr-btn fr-btn--primary fr-mx-1w" data-fr-opened="false" aria-controls="share-video-{{ recording.recordID }}" title="Partager l'enregistrement">
+                                <span class="fr-icon-git-branch-line" aria-hidden="true"></span>
+                            </button>
                             {% endif %}
-                            <button class="fr-btn fr-btn--secondary fr-fi-delete-line fr-mx-1w""  data-fr-opened="false" aria-controls="delete-video-{{ recording.recordID }}">
+                            {% endif %}
+                            <button class="fr-btn fr-btn--secondary fr-fi-delete-line fr-mx-1w"  data-fr-opened="false" aria-controls="delete-video-{{ recording.recordID }}">
                                 {% trans meeting_name=meeting.name %}Supprimer video de {{ meeting_name }}{% endtrans %}
                             </button>
                         </div>
@@ -144,6 +148,40 @@
                                     </li>
                                 </ul>
                             </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </dialog>
+
+    <!-- Partager la video -->
+    <dialog id="share-video-{{ recording.recordID }}" class="fr-modal" role="dialog" aria-labelledby="share-video-{{ recording.recordID }}-title">
+        <div class="fr-container fr-container--fluid fr-container-md">
+            <div class="fr-grid-row fr-grid-row--center">
+                <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                    <div class="fr-modal__body">
+                        <div class="fr-modal__header">
+                            <button class="fr-btn--close fr-btn" aria-controls="share-video-{{ recording.recordID }}" title="Fermer">
+                                Fermer
+                            </button>
+                        </div>
+                        <div class="fr-modal__content">
+                            <h1 id="share-video-{{ recording.recordID }}-title" class="fr-modal__title">
+                                <span class="" aria-hidden="true"></span>
+                                Partager l'enregistrement de "<em>{{ recording_name }}</em>"
+                            </h1>
+                            {% if recording.playbacks.get("video") %}
+                            {% if recording.playbacks.video.get("direct_link") %}
+                            <div class="fr-grid-row fr-grid-row--center">
+                                <input class="fr-input fr-col-9" type="text" readonly value="{{ recording.playbacks.video.direct_link }}">
+                                <button type="button" class="fr-btn fr-btn--sm fr-btn--primary fr-col-3" id="meeting-{{ meeting.id }}-moderator-copy" onclick="navigator.clipboard.writeText('{{ recording.playbacks.video.direct_link }}');" title="Copier le lien de l'enregistrement dans le presse-papiers">
+                                    <span class="fr-icon-clipboard-line"></span> 
+                                    Copier
+                                </button>
+                            </div>
+                            {% endif %}
+                            {% endif %}
                         </div>
                     </div>
                 </div>

--- a/web/tests/meeting/test_recordings.py
+++ b/web/tests/meeting/test_recordings.py
@@ -13,103 +13,103 @@ def bbb_getRecordings_response(mocker):
 
         content = """
 <response>
-   <returncode>SUCCESS</returncode>
-   <recordings>
-      <recording>
-         <recordID>ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124</recordID>
-         <meetingID>c637ba21adcd0191f48f5c4bf23fab0f96ed5c18</meetingID>
-         <internalMeetingID>ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124</internalMeetingID>
-         <name>Fred's Room</name>
-         <isBreakout>false</isBreakout>
-         <published>true</published>
-         <state>published</state>
-         <startTime>1530718721124</startTime>
-         <endTime>1530718810456</endTime>
-         <participants>3</participants>
-         <rawSize>951067</rawSize>
-         <metadata>
-            <analytics-callback-url>https://bbb-analytics.url</analytics-callback-url>
-            <isBreakout>false</isBreakout>
-            <meetingId>c637ba21adcd0191f48f5c4bf23fab0f96ed5c18</meetingId>
-            <meetingName>Fred's Room</meetingName>
-         </metadata>
-         <breakout>
-            <parentId>unknown</parentId>
-            <sequence>0</sequence>
-            <freeJoin>false</freeJoin>
-         </breakout>
-         <size>1104836</size>
-         <playback>
-            <format>
-               <type>presentation</type>
-               <url>https://demo.bigbluebutton.org/playback/presentation/2.0/playback.html?meetingId=ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124</url>
-               <processingTime>7177</processingTime>
-               <length>0</length>
-               <size>1104836</size>
-               <preview>
-                  <images>
-                     <image alt="Welcome to" height="136" width="176">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530718721134/thumbnails/thumb-1.png</image>
-                     <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530718721134/thumbnails/thumb-2.png</image>
-                     <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530718721134/thumbnails/thumb-3.png</image>
-                  </images>
-               </preview>
-            </format>
-            <format>
-               <type>video</type>
-               <url>https://demo.bigbluebutton.org/podcast/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/meeting.mp4</url>
-               <processingTime>0</processingTime>
-               <length>0</length>
-               <size>1104836</size>
-            </format>
-         </playback>
-      </recording>
-      <recording>
-         <recordID>ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111</recordID>
-         <meetingID>c637ba21adcd0191f48f5c4bf23fab0f96ed5c18</meetingID>
-         <internalMeetingID>ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111</internalMeetingID>
-         <name>Fred's Room</name>
-         <isBreakout>false</isBreakout>
-         <published>true</published>
-         <state>published</state>
-         <startTime>1530278898111</startTime>
-         <endTime>1530281194326</endTime>
-         <participants>7</participants>
-         <rawSize>381530</rawSize>
-         <metadata>
-            <name>Recording title hand written</name>
-            <meetingName>Fred's Room</meetingName>
-            <meetingId>c637ba21adcd0191f48f5c4bf23fab0f96ed5c18</meetingId>
-            <analytics-callback-url>https://bbb-analytics.url</analytics-callback-url>
-            <isBreakout>false</isBreakout>
-         </metadata>
-         <breakout>
-            <parentId>unknown</parentId>
-            <sequence>0</sequence>
-            <freeJoin>false</freeJoin>
-         </breakout>
-         <playback>
-            <format>
-               <type>podcast</type>
-               <url>https://demo.bigbluebutton.org/podcast/ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111/audio.ogg</url>
-               <processingTime>0</processingTime>
-               <length>33</length>
-            </format>
-            <format>
-               <type>presentation</type>
-               <url>https://demo.bigbluebutton.org/playback/presentation/2.0/playback.html?meetingId=ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111</url>
-               <processingTime>139458</processingTime>
-               <length>33</length>
-               <preview>
-                  <images>
-                     <image width="176" height="136" alt="Welcome to">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530278898120/thumbnails/thumb-1.png</image>
-                     <image width="176" height="136" alt="(this slide left blank for use as a whiteboard)">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530278898120/thumbnails/thumb-2.png</image>
-                     <image width="176" height="136" alt="(this slide left blank for use as a whiteboard)">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530278898120/thumbnails/thumb-3.png</image>
-                  </images>
-               </preview>
-            </format>
-         </playback>
-      </recording>
-   </recordings>
+  <returncode>SUCCESS</returncode>
+  <recordings>
+    <recording>
+      <recordID>ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124</recordID>
+      <meetingID>c637ba21adcd0191f48f5c4bf23fab0f96ed5c18</meetingID>
+      <internalMeetingID>ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124</internalMeetingID>
+      <name>Fred's Room</name>
+      <isBreakout>false</isBreakout>
+      <published>true</published>
+      <state>published</state>
+      <startTime>1530718721124</startTime>
+      <endTime>1530718810456</endTime>
+      <participants>3</participants>
+      <rawSize>951067</rawSize>
+      <metadata>
+        <analytics-callback-url>https://bbb-analytics.url</analytics-callback-url>
+        <isBreakout>false</isBreakout>
+        <meetingId>c637ba21adcd0191f48f5c4bf23fab0f96ed5c18</meetingId>
+        <meetingName>Fred's Room</meetingName>
+      </metadata>
+      <breakout>
+        <parentId>unknown</parentId>
+        <sequence>0</sequence>
+        <freeJoin>false</freeJoin>
+      </breakout>
+      <size>1104836</size>
+      <playback>
+        <format>
+          <type>presentation</type>
+          <url>https://demo.bigbluebutton.org/playback/presentation/2.0/playback.html?meetingId=ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124</url>
+          <processingTime>7177</processingTime>
+          <length>0</length>
+          <size>1104836</size>
+          <preview>
+            <images>
+              <image alt="Welcome to" height="136" width="176">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530718721134/thumbnails/thumb-1.png</image>
+              <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530718721134/thumbnails/thumb-2.png</image>
+              <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530718721134/thumbnails/thumb-3.png</image>
+            </images>
+          </preview>
+        </format>
+        <format>
+          <type>video</type>
+          <url>https://demo.bigbluebutton.org/podcast/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/meeting.mp4</url>
+          <processingTime>0</processingTime>
+          <length>0</length>
+          <size>1104836</size>
+        </format>
+      </playback>
+    </recording>
+    <recording>
+      <recordID>ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111</recordID>
+      <meetingID>c637ba21adcd0191f48f5c4bf23fab0f96ed5c18</meetingID>
+      <internalMeetingID>ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111</internalMeetingID>
+      <name>Fred's Room</name>
+      <isBreakout>false</isBreakout>
+      <published>true</published>
+      <state>published</state>
+      <startTime>1530278898111</startTime>
+      <endTime>1530281194326</endTime>
+      <participants>7</participants>
+      <rawSize>381530</rawSize>
+      <metadata>
+        <name>Recording title hand written</name>
+        <meetingName>Fred's Room</meetingName>
+        <meetingId>c637ba21adcd0191f48f5c4bf23fab0f96ed5c18</meetingId>
+        <analytics-callback-url>https://bbb-analytics.url</analytics-callback-url>
+        <isBreakout>false</isBreakout>
+      </metadata>
+      <breakout>
+        <parentId>unknown</parentId>
+        <sequence>0</sequence>
+        <freeJoin>false</freeJoin>
+      </breakout>
+      <playback>
+        <format>
+          <type>podcast</type>
+          <url>https://demo.bigbluebutton.org/podcast/ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111/audio.ogg</url>
+          <processingTime>0</processingTime>
+          <length>33</length>
+        </format>
+        <format>
+          <type>presentation</type>
+          <url>https://demo.bigbluebutton.org/playback/presentation/2.0/playback.html?meetingId=ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111</url>
+          <processingTime>139458</processingTime>
+          <length>33</length>
+          <preview>
+            <images>
+              <image width="176" height="136" alt="Welcome to">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530278898120/thumbnails/thumb-1.png</image>
+              <image width="176" height="136" alt="(this slide left blank for use as a whiteboard)">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530278898120/thumbnails/thumb-2.png</image>
+              <image width="176" height="136" alt="(this slide left blank for use as a whiteboard)">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530278898120/thumbnails/thumb-3.png</image>
+            </images>
+          </preview>
+        </format>
+      </playback>
+    </recording>
+  </recordings>
 </response>
 """
         text = ""
@@ -117,7 +117,11 @@ def bbb_getRecordings_response(mocker):
     yield mocker.patch("requests.Session.send", return_value=Response)
 
 
-def test_get_recordings(meeting, bbb_getRecordings_response):
+def test_get_recordings(mocker, meeting, bbb_getRecordings_response):
+    class DirectLinkRecording:
+        status_code = 200
+
+    mocker.patch("b3desk.models.bbb.requests.get", return_value=DirectLinkRecording)
     recordings = meeting.bbb.get_recordings()
 
     assert len(recordings) == 2

--- a/web/tests/test_bbb_api_caching.py
+++ b/web/tests/test_bbb_api_caching.py
@@ -36,103 +36,103 @@ def test_is_meeting_running(meeting, mocker):
 
 GET_RECORDINGS_RESPONSE = """
 <response>
-   <returncode>SUCCESS</returncode>
-   <recordings>
-      <recording>
-         <recordID>ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124</recordID>
-         <meetingID>c637ba21adcd0191f48f5c4bf23fab0f96ed5c18</meetingID>
-         <internalMeetingID>ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124</internalMeetingID>
-         <name>Fred's Room</name>
-         <isBreakout>false</isBreakout>
-         <published>true</published>
-         <state>published</state>
-         <startTime>1530718721124</startTime>
-         <endTime>1530718810456</endTime>
-         <participants>3</participants>
-         <rawSize>951067</rawSize>
-         <metadata>
-            <analytics-callback-url>https://bbb-analytics.url</analytics-callback-url>
-            <isBreakout>false</isBreakout>
-            <meetingId>c637ba21adcd0191f48f5c4bf23fab0f96ed5c18</meetingId>
-            <meetingName>Fred's Room</meetingName>
-         </metadata>
-         <breakout>
-            <parentId>unknown</parentId>
-            <sequence>0</sequence>
-            <freeJoin>false</freeJoin>
-         </breakout>
-         <size>1104836</size>
-         <playback>
-            <format>
-               <type>presentation</type>
-               <url>https://demo.bigbluebutton.org/playback/presentation/2.0/playback.html?meetingId=ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124</url>
-               <processingTime>7177</processingTime>
-               <length>0</length>
-               <size>1104836</size>
-               <preview>
-                  <images>
-                     <image alt="Welcome to" height="136" width="176">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530718721134/thumbnails/thumb-1.png</image>
-                     <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530718721134/thumbnails/thumb-2.png</image>
-                     <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530718721134/thumbnails/thumb-3.png</image>
-                  </images>
-               </preview>
-            </format>
-            <format>
-               <type>video</type>
-               <url>https://demo.bigbluebutton.org/podcast/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/meeting.mp4</url>
-               <processingTime>0</processingTime>
-               <length>0</length>
-               <size>1104836</size>
-            </format>
-         </playback>
-      </recording>
-      <recording>
-         <recordID>ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111</recordID>
-         <meetingID>c637ba21adcd0191f48f5c4bf23fab0f96ed5c18</meetingID>
-         <internalMeetingID>ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111</internalMeetingID>
-         <name>Fred's Room</name>
-         <isBreakout>false</isBreakout>
-         <published>true</published>
-         <state>published</state>
-         <startTime>1530278898111</startTime>
-         <endTime>1530281194326</endTime>
-         <participants>7</participants>
-         <rawSize>381530</rawSize>
-         <metadata>
-            <name>Recording title hand written</name>
-            <meetingName>Fred's Room</meetingName>
-            <meetingId>c637ba21adcd0191f48f5c4bf23fab0f96ed5c18</meetingId>
-            <analytics-callback-url>https://bbb-analytics.url</analytics-callback-url>
-            <isBreakout>false</isBreakout>
-         </metadata>
-         <breakout>
-            <parentId>unknown</parentId>
-            <sequence>0</sequence>
-            <freeJoin>false</freeJoin>
-         </breakout>
-         <playback>
-            <format>
-               <type>podcast</type>
-               <url>https://demo.bigbluebutton.org/podcast/ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111/audio.ogg</url>
-               <processingTime>0</processingTime>
-               <length>33</length>
-            </format>
-            <format>
-               <type>presentation</type>
-               <url>https://demo.bigbluebutton.org/playback/presentation/2.0/playback.html?meetingId=ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111</url>
-               <processingTime>139458</processingTime>
-               <length>33</length>
-               <preview>
-                  <images>
-                     <image width="176" height="136" alt="Welcome to">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530278898120/thumbnails/thumb-1.png</image>
-                     <image width="176" height="136" alt="(this slide left blank for use as a whiteboard)">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530278898120/thumbnails/thumb-2.png</image>
-                     <image width="176" height="136" alt="(this slide left blank for use as a whiteboard)">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530278898120/thumbnails/thumb-3.png</image>
-                  </images>
-               </preview>
-            </format>
-         </playback>
-      </recording>
-   </recordings>
+  <returncode>SUCCESS</returncode>
+  <recordings>
+    <recording>
+      <recordID>ffbfc4cc24428694e8b53a4e144f414052œ431693-1530718721124</recordID>
+      <meetingID>c637ba21adcd0191f48f5c4bf23fab0f96ed5c18</meetingID>
+      <internalMeetingID>ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124</internalMeetingID>
+      <name>Fred's Room</name>
+      <isBreakout>false</isBreakout>
+      <published>true</published>
+      <state>published</state>
+      <startTime>1530718721124</startTime>
+      <endTime>1530718810456</endTime>
+      <participants>3</participants>
+      <rawSize>951067</rawSize>
+      <metadata>
+        <analytics-callback-url>https://bbb-analytics.url</analytics-callback-url>
+        <isBreakout>false</isBreakout>
+        <meetingId>c637ba21adcd0191f48f5c4bf23fab0f96ed5c18</meetingId>
+        <meetingName>Fred's Room</meetingName>
+      </metadata>
+      <breakout>
+        <parentId>unknown</parentId>
+        <sequence>0</sequence>
+        <freeJoin>false</freeJoin>
+      </breakout>
+      <size>1104836</size>
+      <playback>
+        <format>
+          <type>presentation</type>
+          <url>https://demo.bigbluebutton.org/playback/presentation/2.0/playback.html?meetingId=ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124</url>
+          <processingTime>7177</processingTime>
+          <length>0</length>
+          <size>1104836</size>
+          <preview>
+            <images>
+              <image alt="Welcome to" height="136" width="176">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530718721134/thumbnails/thumb-1.png</image>
+              <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530718721134/thumbnails/thumb-2.png</image>
+              <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530718721134/thumbnails/thumb-3.png</image>
+            </images>
+          </preview>
+        </format>
+        <format>
+          <type>video</type>
+          <url>https://demo.bigbluebutton.org/podcast/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/meeting.mp4</url>
+          <processingTime>0</processingTime>
+          <length>0</length>
+          <size>1104836</size>
+        </format>
+      </playback>
+    </recording>
+    <recording>
+      <recordID>ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111</recordID>
+      <meetingID>c637ba21adcd0191f48f5c4bf23fab0f96ed5c18</meetingID>
+      <internalMeetingID>ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111</internalMeetingID>
+      <name>Fred's Room</name>
+      <isBreakout>false</isBreakout>
+      <published>true</published>
+      <state>published</state>
+      <startTime>1530278898111</startTime>
+      <endTime>1530281194326</endTime>
+      <participants>7</participants>
+      <rawSize>381530</rawSize>
+      <metadata>
+        <name>Recording title hand written</name>
+        <meetingName>Fred's Room</meetingName>
+        <meetingId>c637ba21adcd0191f48f5c4bf23fab0f96ed5c18</meetingId>
+        <analytics-callback-url>https://bbb-analytics.url</analytics-callback-url>
+        <isBreakout>false</isBreakout>
+      </metadata>
+      <breakout>
+        <parentId>unknown</parentId>
+        <sequence>0</sequence>
+        <freeJoin>false</freeJoin>
+      </breakout>
+      <playback>
+        <format>
+          <type>podcast</type>
+          <url>https://demo.bigbluebutton.org/podcast/ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111/audio.ogg</url>
+          <processingTime>0</processingTime>
+          <length>33</length>
+        </format>
+        <format>
+          <type>presentation</type>
+          <url>https://demo.bigbluebutton.org/playback/presentation/2.0/playback.html?meetingId=ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111</url>
+          <processingTime>139458</processingTime>
+          <length>33</length>
+          <preview>
+            <images>
+              <image width="176" height="136" alt="Welcome to">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530278898120/thumbnails/thumb-1.png</image>
+              <image width="176" height="136" alt="(this slide left blank for use as a whiteboard)">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530278898120/thumbnails/thumb-2.png</image>
+              <image width="176" height="136" alt="(this slide left blank for use as a whiteboard)">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530278898111/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530278898120/thumbnails/thumb-3.png</image>
+            </images>
+          </preview>
+        </format>
+      </playback>
+    </recording>
+  </recordings>
 </response>
 """
 
@@ -145,7 +145,11 @@ def test_get_recordings(meeting, mocker):
         content = GET_RECORDINGS_RESPONSE
         text = ""
 
+    class DirectLinkRecording:
+        status_code = 200
+
     send = mocker.patch("requests.Session.send", return_value=Response)
+    mocker.patch("b3desk.models.bbb.requests.get", return_value=DirectLinkRecording)
 
     assert send.call_count == 0
 


### PR DESCRIPTION
![Recording link](https://github.com/user-attachments/assets/e9c206b8-ddf2-4084-964a-3f73db7b08ea)

Je ne suis pas entièrement satisfait. On en avait parlé il y a plusieurs mois, mais BBB n'a pas d'interface pour fournir directement un lien vers le fichier vidéo, seulement des liens qui permettent de lire plusieurs flux en même temps (les webcams, les diapo, le chat, etc.)
On a néanmoins un "pattern" : la vidéo est accessible en ajoutant à l'url `<video>` fourni par `getRecordings` ne nom du fichier qui semble toujours être "video-0.m4v". Cette vidéo ne contient que le son et les diapo.
Ça a donc été ajouté "en dur" dans le code. Mais le jour où BBB change sa façon de stocker les vidéo, il n'y aura plus de bouton de partage.
