### PR TITLE
adds created_at info in user table

### DIFF
--- a/web/b3desk/models/users.py
+++ b/web/b3desk/models/users.py
@@ -305,6 +305,7 @@ class User(db.Model):
     nc_token = db.Column(db.Unicode(255))
     nc_last_auto_enroll = db.Column(db.DateTime)
     last_connection_utc_datetime = db.Column(db.DateTime)
+    created_at = db.Column(db.DateTime, default=datetime.now, nullable=False)
 
     meetings = db.relationship("Meeting", back_populates="user")
 

--- a/web/migrations/versions/454adc444042_adds_created_at_in_user.py
+++ b/web/migrations/versions/454adc444042_adds_created_at_in_user.py
@@ -1,0 +1,35 @@
+"""adds created_at in user
+
+Revision ID: 454adc444042
+Revises: 3c8b6c640fee
+Create Date: 2025-09-03 08:36:49.556214
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "454adc444042"
+down_revision = "3c8b6c640fee"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("user", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "created_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.text("'1900-01-01 00:00:00'"),
+            )
+        )
+
+    with op.batch_alter_table("user", schema=None) as batch_op:
+        batch_op.alter_column("created_at", server_default=None)
+
+
+def downgrade():
+    with op.batch_alter_table("user", schema=None) as batch_op:
+        batch_op.drop_column("created_at")

--- a/web/tests/test_user.py
+++ b/web/tests/test_user.py
@@ -27,6 +27,7 @@ def test_get_or_create_user(client_app):
     assert user.family_name == "Cooper"
     assert user.email == "alice@mydomain.test"
     assert user.last_connection_utc_datetime.date() == date.today()
+    assert user.created_at.date() == date.today()
 
 
 def test_update_last_connection_if_more_than_24h(client_app):
@@ -45,7 +46,8 @@ def test_update_last_connection_if_more_than_24h(client_app):
 
         get_or_create_user(user_info)
 
-        assert user.last_connection_utc_datetime.date() == date(2021, 8, 11)
+    assert user.last_connection_utc_datetime.date() == date(2021, 8, 11)
+    assert user.created_at.date() == date(2021, 8, 10)
 
 
 def test_make_nextcloud_credentials_request_with_scheme_response(


### PR DESCRIPTION
fixes #191

### Migration
adds a new column in user : `created_at`

For users created before migration, `created_at` is 01/01/1900

### To test this PR
1. Do migration
2. Check `created_at` on an old user
3. Create a new user
4. Check `create_at` on this new user
