### PR TITLE
doc: add configuration examples

### DIFF
--- a/documentation/maintainers/settings.rst
+++ b/documentation/maintainers/settings.rst
@@ -97,6 +97,18 @@ On peut ensuite configurer les paramètres suivants de manière identique pour t
 - :attr:`~b3desk.settings.MainSettings.FQDN_SIP_SERVER`
 - :attr:`~b3desk.settings.MainSettings.PRIVATE_KEY`
 
+.. code-block:: bash
+   :caption: web.env
+
+   ENABLE_SIP=on
+   FQDN_SIP_SERVER=example.serveur.com
+   PRIVATE_KEY="-----BEGIN PRIVATE KEY-----
+   ThereIsAWonderfulPrivateKey
+   -----END PRIVATE KEY-----"
+
+.. warning::
+   Pour les données s'étalant sur plusieurs lignes, pensez à les entourer de guillements doubles ``"``.
+
 Il est maintenant nécessaire de redémarrer le conteneur de chaque serveur :
 
 .. code-block:: bash


### PR DESCRIPTION
https://github.com/numerique-gouv/b3desk/issues/169#issuecomment-3249079108

> Changer docs pour SIP Token :
>
>    Mettre un exemple de PRIVATE_KEY car il faut les guillemets
