### PR TITLE
Correction de l'erreur lors du téléversement de documents

### DIFF
--- a/web/b3desk/endpoints/meeting_files.py
+++ b/web/b3desk/endpoints/meeting_files.py
@@ -433,7 +433,7 @@ def add_dropzone_files(meeting: Meeting, owner: User):
     # but not if it's new file that would overwrite the existing one
     if os.path.exists(save_path) and current_chunk == 0:
         # 400 and 500s will tell dropzone that an error occurred and show an error
-        return make_response((_("Le fichier a déjà été mis en ligne"), 500))
+        return make_response((str(_("Le fichier a déjà été mis en ligne")), 500))
 
     try:
         with open(save_path, "ab") as f:
@@ -442,7 +442,7 @@ def add_dropzone_files(meeting: Meeting, owner: User):
 
     except OSError:
         return make_response(
-            (_("Erreur lors de l'écriture du fichier sur le disque"), 500)
+            (str(_("Erreur lors de l'écriture du fichier sur le disque")), 500)
         )
 
     total_chunks = int(request.form["dztotalchunkcount"])


### PR DESCRIPTION
fixes #231 

lazystring occured an error in make_response

```
TypeError: The view function did not return a valid response. The return type must be a string, dict, list, tuple with headers or status, Response instance, or WSGI callable, but it wa
```