### PR TITLE
Correction du clic milieu pour coller les visio-codes

### DIFF
--- a/web/b3desk/static/js/visio_code_form.js
+++ b/web/b3desk/static/js/visio_code_form.js
@@ -223,6 +223,7 @@ inputs.forEach((input) => {
                 focusAtEnd(pastedInput);
             }
         })
+        updateSumbitButtonStatus(event, input);
     });
 })
 


### PR DESCRIPTION
fixes #247 

From now, when user use middle click or right click to paste visio-code, the connexion button does not remain disabled.