### PR TITLE
Ouverture de l'accordéon adéquat lors des erreurs sur le formulaire d'édition d'un salon

### DIFF
--- a/web/b3desk/templates/meeting/form.html
+++ b/web/b3desk/templates/meeting/form.html
@@ -71,7 +71,7 @@
   <div class="fr-accordions-group" id="meeting-form-accordion">
     <div class="fr-accordion">
       <h2 class="fr-accordion__title fr-h3">
-        <button type="button" class="fr-accordion__btn fr-accordion__btn--icon-right" aria-expanded="false" aria-controls="meeting-form-accordion-body-1">{% trans %}Accueil des participants{% endtrans %}</button>
+        <button type="button" class="fr-accordion__btn fr-accordion__btn--icon-right" aria-expanded="{{ 'true' if form.errors else 'false'}}" aria-controls="meeting-form-accordion-body-1">{% trans %}Accueil des participants{% endtrans %}</button>
       </h2>
       <div class="fr-collapse" id="meeting-form-accordion-body-1" aria-labelledby="meeting-form-accordion-body-1">
         <div class="fr-grid-row">


### PR DESCRIPTION
when there is an error in meeting form on edit page, the first dsfr-accordion is open and not the second for now, only one dsfr-accordion can be open at a time

#250 