### PR TITLE
Suppression de l'utilisateur dans les URLs des liens d'invitation

### DIFF
--- a/web/b3desk/endpoints/meetings.py
+++ b/web/b3desk/endpoints/meetings.py
@@ -26,7 +26,7 @@ from b3desk.forms import MeetingWithRecordForm
 from b3desk.forms import RecordingForm
 from b3desk.models import db
 from b3desk.models.meetings import Meeting
-from b3desk.models.meetings import get_quick_meeting_from_user_and_fake_id
+from b3desk.models.meetings import get_quick_meeting_from_fake_id
 from b3desk.models.meetings import save_voiceBridge_and_delete_meeting
 from b3desk.models.meetings import unique_visio_code_generation
 from b3desk.models.roles import Role
@@ -75,10 +75,7 @@ def quick_mail_meeting():
             "error_login",
         )
         return redirect(url_for("public.index"))
-    user = User(
-        id=email
-    )  # this user can probably be removed if we created adock function
-    meeting = get_quick_meeting_from_user_and_fake_id(user)
+    meeting = get_quick_meeting_from_fake_id()
     send_quick_meeting_mail(meeting, email)
     flash(_("Vous avez reçu un courriel pour vous connecter"), "success_login")
     return redirect(url_for("public.index"))
@@ -89,8 +86,8 @@ def quick_mail_meeting():
 @auth.oidc_auth("default")
 def quick_meeting():
     """Create and join a quick meeting for the authenticated user."""
-    meeting = get_quick_meeting_from_user_and_fake_id(g.user)
-    created = meeting.create_bbb()
+    meeting = get_quick_meeting_from_fake_id()
+    created = meeting.create_bbb(g.user)
     return redirect(
         meeting.get_join_url(
             Role.moderator,
@@ -287,7 +284,7 @@ def end_meeting():
 @meeting_owner_needed
 def create_meeting(meeting: Meeting, owner: User):
     """Create the meeting on BBB server."""
-    meeting.create_bbb()
+    meeting.create_bbb(g.user)
     meeting.visio_code = (
         meeting.visio_code if meeting.visio_code else unique_visio_code_generation()
     )

--- a/web/b3desk/forms.py
+++ b/web/b3desk/forms.py
@@ -17,7 +17,6 @@ from b3desk.models.meetings import pin_is_unique_validator
 class JoinMeetingForm(FlaskForm):
     fullname = StringField()
     meeting_fake_id = StringField()
-    user_id = IntegerField()
     h = StringField()
     fullname_suffix = StringField()
     seconds_before_refresh = FloatField()

--- a/web/b3desk/models/bbb.py
+++ b/web/b3desk/models/bbb.py
@@ -114,7 +114,7 @@ class BBB:
         )
         return self.bbb_response(request)
 
-    def create(self):
+    def create(self, user=None):
         """Create a new meeting.
 
         https://docs.bigbluebutton.org/development/api/#create.
@@ -173,8 +173,8 @@ class BBB:
 
         # Pass the academy for statisticts purpose
         # https://github.com/numerique-gouv/b3desk/issues/80
-        if self.meeting.user and self.meeting.user.mail_domain:
-            params["meta_academy"] = self.meeting.user.mail_domain
+        if user and user.mail_domain:
+            params["meta_academy"] = user.mail_domain
 
         bigbluebutton_analytics_callback_url = current_app.config[
             "BIGBLUEBUTTON_ANALYTICS_CALLBACK_URL"

--- a/web/b3desk/templates/meeting/join.html
+++ b/web/b3desk/templates/meeting/join.html
@@ -6,7 +6,6 @@
     <form id="joinMeetingForm" action="{{ url_for("join.join_meeting") }}" method="POST">
         {% include 'meeting/csrf.html' %}
         <input type="hidden" id="meetingID" name="meeting_fake_id" value="{{ meeting_fake_id }}" />
-        <input type="hidden" id="user_id" name="user_id" value="{{ creator.id }}" />
         <input type="hidden" id="h" name="h" value="{{ h }}" />
 
         <div class="fr-input-group">
@@ -39,7 +38,7 @@
                 <div class="fr-grid-row fr-grid-row--gutters">
                     <div class="fr-col">
                         {% trans %}Vous êtes propriétaire de cette salle ?{% endtrans %}
-                        <a href="{{ url_for("join.authenticate_then_signin_meeting", meeting_fake_id=meeting_fake_id, creator=creator, h=h ) }}">
+                        <a href="{{ url_for("join.authenticate_then_signin_meeting", meeting_fake_id=meeting_fake_id, h=h ) }}">
                             {% trans %}S’identifier{% endtrans %}
                         </a>
                     </div>

--- a/web/b3desk/templates/meeting/signinmail.html
+++ b/web/b3desk/templates/meeting/signinmail.html
@@ -5,7 +5,6 @@
   <form action="{{ url_for("join.join_mail_meeting") }}" method="POST">
     {% include 'meeting/csrf.html' %}
     <input type="hidden" id="meetingID" name="meeting_fake_id" value="{{ meeting_fake_id }}" />
-    <input type="hidden" id="user_id" name="user_id" value="{{ user_id }}" />
     <input type="hidden" id="expiration" name="expiration" value="{{ expiration }}" />
     <input type="hidden" id="h" name="h" value="{{ h }}" />
     {% if not g.user %}

--- a/web/b3desk/templates/meeting/wait.html
+++ b/web/b3desk/templates/meeting/wait.html
@@ -28,7 +28,6 @@
             <form id="joinMeetingForm" action="{{ url_for("join.join_meeting") }}" method="POST">
                 {% include 'meeting/csrf.html' %}
                 <input type="hidden" id="meetingID" name="meeting_fake_id" value="{{ meeting_fake_id }}" />
-                <input type="hidden" id="user_id" name="user_id" value="{{ creator.id }}" />
                 <input type="hidden" id="h" name="h" value="{{ h }}" />
                 <input type="hidden" id="fullname" name="fullname" value="{{ fullname }}" />
                 <input type="hidden" id="fullname_suffix" name="fullname_suffix" value="{{ fullname_suffix }}" />

--- a/web/tests/meeting/test_join.py
+++ b/web/tests/meeting/test_join.py
@@ -26,7 +26,7 @@ def test_signin_meeting(client_app, meeting, user, bbb_response):
     """Test that attendee can sign in to meeting."""
     meeting_hash = meeting.get_hash(Role.attendee)
 
-    url = f"/meeting/signin/{meeting.id}/creator/{meeting.user.id}/hash/{meeting_hash}"
+    url = f"/meeting/signin/{meeting.id}/hash/{meeting_hash}"
     response = client_app.get(
         url, extra_environ={"REMOTE_ADDR": "127.0.0.1"}, status=200
     )
@@ -49,7 +49,7 @@ def test_attendee_link_moderator_promotion_for_meeting_owner_already_authenticat
 ):
     """If the meeting owner are authenticated, they must be automatically promoted moderator in the meeting when clicking on an attendee link."""
     meeting_hash = meeting.get_hash(Role.attendee)
-    url = f"/meeting/signin/{meeting.id}/creator/{meeting.user.id}/hash/{meeting_hash}"
+    url = f"/meeting/signin/{meeting.id}/hash/{meeting_hash}"
 
     response = client_app.get(
         url, extra_environ={"REMOTE_ADDR": "127.0.0.1"}, status=200
@@ -64,7 +64,7 @@ def test_signin_meeting_with_authenticated_attendee(client_app, meeting):
     """Test that authenticated attendee is redirected to join endpoint."""
     meeting_hash = meeting.get_hash(Role.authenticated)
 
-    url = f"/meeting/signin/{meeting.id}/creator/{meeting.user.id}/hash/{meeting_hash}"
+    url = f"/meeting/signin/{meeting.id}/hash/{meeting_hash}"
     response = client_app.get(
         url, extra_environ={"REMOTE_ADDR": "127.0.0.1"}, status=302
     )
@@ -80,7 +80,7 @@ def test_auth_attendee_disabled(client_app, meeting):
     client_app.app.config["OIDC_ATTENDEE_ENABLED"] = False
     meeting_hash = meeting.get_hash(Role.authenticated)
 
-    url = f"/meeting/signin/{meeting.id}/creator/{meeting.user.id}/hash/{meeting_hash}"
+    url = f"/meeting/signin/{meeting.id}/hash/{meeting_hash}"
     response = client_app.get(
         url, extra_environ={"REMOTE_ADDR": "127.0.0.1"}, status=200
     )
@@ -94,7 +94,7 @@ def test_join_meeting_as_authenticated_attendee(
     url = f"/meeting/join/{meeting.id}/authenticated"
     response = client_app.get(url, status=302)
 
-    assert "/meeting/wait/1/creator/1/hash/" in response.location
+    assert "/meeting/wait/1/hash/" in response.location
     assert "Bob%20Dylan" in response.location
 
     response = response.follow()
@@ -122,7 +122,7 @@ def test_fix_authenticated_attendee_name_case(client_app, meeting, user):
     url = f"/meeting/join/{meeting.id}/authenticated"
     response = client_app.get(url, status=302)
 
-    assert "/meeting/wait/1/creator/1/hash/" in response.location
+    assert "/meeting/wait/1/hash/" in response.location
     assert "John%20Lennon" in response.location
 
     response = response.follow()
@@ -163,9 +163,7 @@ def test_join_meeting_as_authenticated_attendee_with_modified_fullname(
 def test_join_meeting(client_app, meeting, bbb_response):
     """Test that guest can join meeting with custom fullname."""
     meeting_hash = meeting.get_hash(Role.attendee)
-    response = client_app.get(
-        f"/meeting/signin/{meeting.id}/creator/{meeting.user.id}/hash/{meeting_hash}"
-    )
+    response = client_app.get(f"/meeting/signin/{meeting.id}/hash/{meeting_hash}")
     response.form["fullname"] = "Bob"
     response = response.form.submit()
 
@@ -184,7 +182,6 @@ def test_join_mail_meeting(client_app, meeting, bbb_response):
         f"/meeting/signinmail/{meeting.id}/expiration/{expiration}/hash/{meeting_hash}"
     )
     response.form["fullname"] = "Bob"
-    response.form["user_id"] = meeting.user.id
     response = response.form.submit()
 
     assert (
@@ -229,7 +226,6 @@ def test_waiting_meeting_with_a_fullname_containing_a_slash(client_app, meeting)
     waiting_meeting_url = url_for(
         "join.waiting_meeting",
         meeting_fake_id=meeting_fake_id,
-        creator=meeting.user,
         h=h,
         fullname=fullname,
         fullname_suffix=fullname_suffix,
@@ -248,7 +244,6 @@ def test_waiting_meeting_with_empty_fullname_suffix(client_app, meeting):
     waiting_meeting_url = url_for(
         "join.waiting_meeting",
         meeting_fake_id=meeting_fake_id,
-        creator=meeting.user,
         h=h,
         fullname=fullname,
         fullname_suffix="",

--- a/web/tests/meeting/test_meeting.py
+++ b/web/tests/meeting/test_meeting.py
@@ -309,7 +309,7 @@ def test_create_no_file(client_app, meeting, mocker, bbb_response):
     meeting.lockSettingsDisablePublicChat = False
     meeting.lockSettingsDisableNote = False
     meeting.guestPolicy = True
-    meeting.bbb.create()
+    meeting.bbb.create(meeting.user)
 
     assert bbb_response.called
     bbb_url = bbb_response.call_args.args[0].url
@@ -332,7 +332,7 @@ def test_create_no_file(client_app, meeting, mocker, bbb_response):
         "logoutURL": "https://log.out",
         "record": "true",
         "duration": "60",
-        "moderatorOnlyMessage": f'Welcome moderators!<br />\n\n Lien Modérateur   : <a href="http://b3desk.test/meeting/signin/moderateur/{meeting.fake_id}/creator/1/hash/{meeting.get_hash(Role.moderator)}" target="_blank">http://b3desk.test/meeting/signin/moderateur/{meeting.fake_id}/creator/1/hash/{meeting.get_hash(Role.moderator)}</a><br />\n\n Lien Participant   : <a href="http://b3desk.test/meeting/signin/invite/{meeting.fake_id}/creator/1/hash/{meeting.get_hash(Role.attendee)}" target="_blank">http://b3desk.test/meeting/signin/invite/{meeting.fake_id}/creator/1/hash/{meeting.get_hash(Role.attendee)}</a>',
+        "moderatorOnlyMessage": f'Welcome moderators!<br />\n\n Lien Modérateur   : <a href="http://b3desk.test/meeting/signin/moderateur/{meeting.fake_id}/hash/{meeting.get_hash(Role.moderator)}" target="_blank">http://b3desk.test/meeting/signin/moderateur/{meeting.fake_id}/hash/{meeting.get_hash(Role.moderator)}</a><br />\n\n Lien Participant   : <a href="http://b3desk.test/meeting/signin/invite/{meeting.fake_id}/hash/{meeting.get_hash(Role.attendee)}" target="_blank">http://b3desk.test/meeting/signin/invite/{meeting.fake_id}/hash/{meeting.get_hash(Role.attendee)}</a>',
         "autoStartRecording": "false",
         "allowStartStopRecording": "true",
         "webcamsOnlyForModerator": "false",
@@ -408,7 +408,7 @@ def test_create_with_only_a_default_file(
     )
     meeting.files = [meeting_file]
 
-    meeting.bbb.create()
+    meeting.bbb.create(meeting.user)
 
     assert bbb_response.called
     bbb_url = bbb_response.call_args.args[0].url
@@ -431,7 +431,7 @@ def test_create_with_only_a_default_file(
         "logoutURL": "https://log.out",
         "record": "true",
         "duration": "60",
-        "moderatorOnlyMessage": f'Welcome moderators!<br />\n\n Lien Modérateur   : <a href="http://b3desk.test/meeting/signin/moderateur/{meeting.fake_id}/creator/1/hash/{meeting.get_hash(Role.moderator)}" target="_blank">http://b3desk.test/meeting/signin/moderateur/{meeting.fake_id}/creator/1/hash/{meeting.get_hash(Role.moderator)}</a><br />\n\n Lien Participant   : <a href="http://b3desk.test/meeting/signin/invite/{meeting.fake_id}/creator/1/hash/{meeting.get_hash(Role.attendee)}" target="_blank">http://b3desk.test/meeting/signin/invite/{meeting.fake_id}/creator/1/hash/{meeting.get_hash(Role.attendee)}</a>',
+        "moderatorOnlyMessage": f'Welcome moderators!<br />\n\n Lien Modérateur   : <a href="http://b3desk.test/meeting/signin/moderateur/{meeting.fake_id}/hash/{meeting.get_hash(Role.moderator)}" target="_blank">http://b3desk.test/meeting/signin/moderateur/{meeting.fake_id}/hash/{meeting.get_hash(Role.moderator)}</a><br />\n\n Lien Participant   : <a href="http://b3desk.test/meeting/signin/invite/{meeting.fake_id}/hash/{meeting.get_hash(Role.attendee)}" target="_blank">http://b3desk.test/meeting/signin/invite/{meeting.fake_id}/hash/{meeting.get_hash(Role.attendee)}</a>',
         "autoStartRecording": "false",
         "allowStartStopRecording": "true",
         "webcamsOnlyForModerator": "false",
@@ -506,7 +506,7 @@ def test_create_with_files(
     )
     meeting.files = [meeting_file]
 
-    meeting.bbb.create()
+    meeting.bbb.create(meeting.user)
 
     assert bbb_response.called
     bbb_url = bbb_response.call_args.args[0].url
@@ -530,7 +530,7 @@ def test_create_with_files(
         "logoutURL": "https://log.out",
         "record": "true",
         "duration": "60",
-        "moderatorOnlyMessage": f'Welcome moderators!<br />\n\n Lien Modérateur   : <a href="http://b3desk.test/meeting/signin/moderateur/{meeting.fake_id}/creator/1/hash/{meeting.get_hash(Role.moderator)}" target="_blank">http://b3desk.test/meeting/signin/moderateur/{meeting.fake_id}/creator/1/hash/{meeting.get_hash(Role.moderator)}</a><br />\n\n Lien Participant   : <a href="http://b3desk.test/meeting/signin/invite/{meeting.fake_id}/creator/1/hash/{meeting.get_hash(Role.attendee)}" target="_blank">http://b3desk.test/meeting/signin/invite/{meeting.fake_id}/creator/1/hash/{meeting.get_hash(Role.attendee)}</a>',
+        "moderatorOnlyMessage": f'Welcome moderators!<br />\n\n Lien Modérateur   : <a href="http://b3desk.test/meeting/signin/moderateur/{meeting.fake_id}/hash/{meeting.get_hash(Role.moderator)}" target="_blank">http://b3desk.test/meeting/signin/moderateur/{meeting.fake_id}/hash/{meeting.get_hash(Role.moderator)}</a><br />\n\n Lien Participant   : <a href="http://b3desk.test/meeting/signin/invite/{meeting.fake_id}/hash/{meeting.get_hash(Role.attendee)}" target="_blank">http://b3desk.test/meeting/signin/invite/{meeting.fake_id}/hash/{meeting.get_hash(Role.attendee)}</a>',
         "autoStartRecording": "false",
         "allowStartStopRecording": "true",
         "webcamsOnlyForModerator": "false",
@@ -599,7 +599,7 @@ def test_save_existing_meeting_gets_default_logoutUrl(
     assert len(Meeting.query.all()) == 1
     meeting = db.session.get(Meeting, 1)
 
-    meeting.bbb.create()
+    meeting.bbb.create(meeting.user)
 
     assert bbb_response.called
     bbb_url = bbb_response.call_args.args[0].url
@@ -616,13 +616,13 @@ def test_save_existing_meeting_gets_default_logoutUrl(
 
 def test_create_quick_meeting(client_app, monkeypatch, user, mocker, bbb_response):
     """Test that quick meeting is created with correct default parameters."""
-    from b3desk.endpoints.meetings import get_quick_meeting_from_user_and_fake_id
+    from b3desk.endpoints.meetings import get_quick_meeting_from_fake_id
 
     mocker.patch("b3desk.tasks.background_upload.delay", return_value=True)
     monkeypatch.setattr("b3desk.models.users.User.id", 1)
     monkeypatch.setattr("b3desk.models.users.User.hash", "hash")
-    meeting = get_quick_meeting_from_user_and_fake_id(user)
-    meeting.bbb.create()
+    meeting = get_quick_meeting_from_fake_id()
+    meeting.bbb.create(user)
 
     assert bbb_response.called
     bbb_url = bbb_response.call_args.args[0].url
@@ -642,7 +642,7 @@ def test_create_quick_meeting(client_app, monkeypatch, user, mocker, bbb_respons
         "meetingKeepEvents": "true",
         "meta_analytics-callback-url": "https://bbb-analytics.test/v1/post_events",
         "meta_academy": "domain.tld",
-        "moderatorOnlyMessage": f'Bienvenue aux modérateurs. Pour inviter quelqu\'un à ce séminaire, envoyez-lui l\'un de ces liens :<br />\n\n Lien Modérateur   : <a href="http://b3desk.test/meeting/signin/moderateur/{meeting.fake_id}/creator/1/hash/{meeting.get_hash(Role.moderator)}" target="_blank">http://b3desk.test/meeting/signin/moderateur/{meeting.fake_id}/creator/1/hash/{meeting.get_hash(Role.moderator)}</a><br />\n\n Lien Participant   : <a href="http://b3desk.test/meeting/signin/invite/{meeting.fake_id}/creator/1/hash/{meeting.get_hash(Role.attendee)}" target="_blank">http://b3desk.test/meeting/signin/invite/{meeting.fake_id}/creator/1/hash/{meeting.get_hash(Role.attendee)}</a>',
+        "moderatorOnlyMessage": f'Bienvenue aux modérateurs. Pour inviter quelqu\'un à ce séminaire, envoyez-lui l\'un de ces liens :<br />\n\n Lien Modérateur   : <a href="http://b3desk.test/meeting/signin/moderateur/{meeting.fake_id}/hash/{meeting.get_hash(Role.moderator)}" target="_blank">http://b3desk.test/meeting/signin/moderateur/{meeting.fake_id}/hash/{meeting.get_hash(Role.moderator)}</a><br />\n\n Lien Participant   : <a href="http://b3desk.test/meeting/signin/invite/{meeting.fake_id}/hash/{meeting.get_hash(Role.attendee)}" target="_blank">http://b3desk.test/meeting/signin/invite/{meeting.fake_id}/hash/{meeting.get_hash(Role.attendee)}</a>',
         "guestPolicy": "ALWAYS_ACCEPT",
         "checksum": mock.ANY,
     }

--- a/web/tests/meeting/test_quick_meeting.py
+++ b/web/tests/meeting/test_quick_meeting.py
@@ -3,7 +3,7 @@ from urllib.parse import urlparse
 
 import pyquery
 from b3desk.models.meetings import Meeting
-from b3desk.models.meetings import get_quick_meeting_from_user_and_fake_id
+from b3desk.models.meetings import get_quick_meeting_from_fake_id
 from b3desk.models.roles import Role
 
 
@@ -78,7 +78,7 @@ def test_join_mail_meeting_with_logged_user(client_app, user, mocker):
 
     mocker.patch("requests.Session.send", return_value=ResponseBBBcreate)
 
-    meeting = get_quick_meeting_from_user_and_fake_id(user)
+    meeting = get_quick_meeting_from_fake_id()
     moderator_mail_signin_url = meeting.get_mail_signin_url()
 
     response = client_app.get(moderator_mail_signin_url, status=200)
@@ -128,7 +128,7 @@ def test_quick_meeting_rasing_time_before_refresh_in_waiting_meeting(
 
 def test_quick_meeting_signin_links_are_accessible(client_app, user):
     """Test that moderator and attendee signin links generated for quick meetings are accessible."""
-    meeting = get_quick_meeting_from_user_and_fake_id(user)
+    meeting = get_quick_meeting_from_fake_id()
 
     moderator_url = meeting.get_signin_url(Role.moderator)
     attendee_url = meeting.get_signin_url(Role.attendee)

--- a/web/tests/meeting/test_shadow_meeting.py
+++ b/web/tests/meeting/test_shadow_meeting.py
@@ -92,7 +92,7 @@ def test_join_meeting_as_moderator_correctly_save_last_connection_date(
     meeting_hash = shadow_meeting.get_hash(Role.moderator)
     previous_connection = shadow_meeting.last_connection_utc_datetime
 
-    url = f"/meeting/signin/{shadow_meeting.id}/creator/{shadow_meeting.user.id}/hash/{meeting_hash}"
+    url = f"/meeting/signin/{shadow_meeting.id}/hash/{meeting_hash}"
     response = client_app.get(
         url, extra_environ={"REMOTE_ADDR": "127.0.0.1"}, status=200
     )
@@ -121,7 +121,7 @@ def test_join_meeting_as_attendee_not_save_last_connection_date(
 
     meeting_hash = shadow_meeting.get_hash(Role.attendee)
 
-    url = f"/meeting/signin/{shadow_meeting.id}/creator/{shadow_meeting.user.id}/hash/{meeting_hash}"
+    url = f"/meeting/signin/{shadow_meeting.id}/hash/{meeting_hash}"
     response = client_app.get(
         url, extra_environ={"REMOTE_ADDR": "127.0.0.1"}, status=200
     )

--- a/web/tests/test_api.py
+++ b/web/tests/test_api.py
@@ -19,8 +19,8 @@ def test_api_meetings_nominal(
     assert res.json["meetings"][2]["name"] == "meeting"
     assert res.json["meetings"][0] == {
         "PIN": "111111111",
-        "attendee_url": "http://b3desk.test/meeting/signin/invite/1/creator/1/hash/9120d7b37d540816e62bea4703bf0376b69297c5",
-        "moderator_url": "http://b3desk.test/meeting/signin/moderateur/1/creator/1/hash/09aa80a2801e126893b2ce209df71cb7281561eb",
+        "attendee_url": "http://b3desk.test/meeting/signin/invite/1/hash/9120d7b37d540816e62bea4703bf0376b69297c5",
+        "moderator_url": "http://b3desk.test/meeting/signin/moderateur/1/hash/09aa80a2801e126893b2ce209df71cb7281561eb",
         "name": "meeting",
         "phone_number": "+33bbbphonenumber",
         "visio_code": "911111111",
@@ -34,8 +34,8 @@ def test_api_meetings_nominal(
     )
 
     assert res.json["meetings"][0] == {
-        "attendee_url": "http://b3desk.test/meeting/signin/invite/1/creator/1/hash/9120d7b37d540816e62bea4703bf0376b69297c5",
-        "moderator_url": "http://b3desk.test/meeting/signin/moderateur/1/creator/1/hash/09aa80a2801e126893b2ce209df71cb7281561eb",
+        "attendee_url": "http://b3desk.test/meeting/signin/invite/1/hash/9120d7b37d540816e62bea4703bf0376b69297c5",
+        "moderator_url": "http://b3desk.test/meeting/signin/moderateur/1/hash/09aa80a2801e126893b2ce209df71cb7281561eb",
         "name": "meeting",
         "visio_code": "911111111",
         "SIPMediaGW_url": "911111111@sip.test",
@@ -48,8 +48,8 @@ def test_api_meetings_nominal(
     )
 
     assert res.json["meetings"][0] == {
-        "attendee_url": "http://b3desk.test/meeting/signin/invite/1/creator/1/hash/9120d7b37d540816e62bea4703bf0376b69297c5",
-        "moderator_url": "http://b3desk.test/meeting/signin/moderateur/1/creator/1/hash/09aa80a2801e126893b2ce209df71cb7281561eb",
+        "attendee_url": "http://b3desk.test/meeting/signin/invite/1/hash/9120d7b37d540816e62bea4703bf0376b69297c5",
+        "moderator_url": "http://b3desk.test/meeting/signin/moderateur/1/hash/09aa80a2801e126893b2ce209df71cb7281561eb",
         "name": "meeting",
         "visio_code": "911111111",
     }
@@ -140,11 +140,11 @@ def test_api_existing_shadow_meeting(
     assert res.json["shadow-meeting"]
     assert res.json["shadow-meeting"][0]["name"] == "shadow meeting"
     assert (
-        f"/meeting/signin/moderateur/{shadow_meeting.id}/creator/{user.id}/hash/"
+        f"/meeting/signin/moderateur/{shadow_meeting.id}/hash/"
         in res.json["shadow-meeting"][0]["moderator_url"]
     )
     assert (
-        f"/meeting/signin/invite/{shadow_meeting.id}/creator/{user.id}/hash/"
+        f"/meeting/signin/invite/{shadow_meeting.id}/hash/"
         in res.json["shadow-meeting"][0]["attendee_url"]
     )
     assert res.json["shadow-meeting"][0]["visio_code"] == "511111111"
@@ -175,11 +175,11 @@ def test_api_new_shadow_meeting(
     assert res.json["shadow-meeting"]
     assert res.json["shadow-meeting"][0]["name"] == "le séminaire de Alice Cooper"
     assert (
-        f"/meeting/signin/moderateur/2/creator/{user.id}/hash/"
+        "/meeting/signin/moderateur/2/hash/"
         in res.json["shadow-meeting"][0]["moderator_url"]
     )
     assert (
-        f"/meeting/signin/invite/2/creator/{user.id}/hash/"
+        "/meeting/signin/invite/2/hash/"
         in res.json["shadow-meeting"][0]["attendee_url"]
     )
     assert res.json["shadow-meeting"][0]["visio_code"]

--- a/web/tests/test_bbb_api_caching.py
+++ b/web/tests/test_bbb_api_caching.py
@@ -195,11 +195,11 @@ def test_create(meeting, mocker):
 
     assert send.call_count == 0
 
-    data = meeting.bbb.create()
+    data = meeting.bbb.create(meeting.user)
     assert data["returncode"] == "SUCCESS"
     assert send.call_count == 1
 
-    data = meeting.bbb.create()
+    data = meeting.bbb.create(meeting.user)
     assert data["returncode"] == "SUCCESS"
     assert send.call_count == 2
 


### PR DESCRIPTION
Meeting invitations no longer require the creator's user ID in the URL. The meeting is now retrieved solely by its fake_id, simplifying URLs and removing unnecessary user coupling for quick meetings.

- Remove user_id from JoinMeetingForm and templates
- Add new routes without creator parameter (old routes kept for compatibility)
- Quick meetings no longer require a user at creation time