### PR TITLE
Logger dédié aux requêtes BBB

### DIFF
--- a/web/b3desk/settings.py
+++ b/web/b3desk/settings.py
@@ -223,6 +223,38 @@ class MainSettings(BaseSettings):
         level = "INFO"
         handlers = ["wsgi"]
 
+    .. code-block:: toml
+        :caption:
+            Exemple de configuration avec les logs BBB dans un fichier dédié,
+            avec DEBUG sur le module BBB uniquement.
+
+        version = 1
+
+        [formatters.default]
+        format = "[%(asctime)s] %(levelname)s in %(module)s: %(message)s"
+
+        [handlers.wsgi]
+        class = "logging.handlers.WatchedFileHandler"
+        filename = "/var/log/wsgi.log"
+        formatter = "default"
+
+        [handlers.bbb]
+        class = "logging.handlers.WatchedFileHandler"
+        filename = "/var/log/bbb.log"
+        formatter = "default"
+
+        [loggers.bbb]
+        level = "DEBUG"
+        handlers = ["bbb"]
+
+        [loggers.b3desk]
+        level = "INFO"
+        handlers = ["wsgi"]
+
+        [root]
+        level = "INFO"
+        handlers = ["wsgi"]
+
     """
 
     REDIS_URL: str | None = None

--- a/web/translations/messages.pot
+++ b/web/translations/messages.pot
@@ -264,15 +264,15 @@ msgstr ""
 msgid "un nouveau séminaire"
 msgstr ""
 
-#: web/b3desk/settings.py:1010
+#: web/b3desk/settings.py:1034
 msgid " Lien Modérateur  "
 msgstr ""
 
-#: web/b3desk/settings.py:1013
+#: web/b3desk/settings.py:1037
 msgid " Lien Participant  "
 msgstr ""
 
-#: web/b3desk/settings.py:1030
+#: web/b3desk/settings.py:1054
 #, python-format
 msgid ""
 "Bienvenue aux modérateurs. Pour inviter quelqu'un à %(this_meeting)s, "


### PR DESCRIPTION
Il y a un logger dédié appelé `bbb` qui permet de logger les messages de debug pour BBB seulement, et pas pour le reste de l'application.

```toml
        ...

        [handlers.bbb]
        class = "logging.handlers.WatchedFileHandler"
        filename = "/var/log/bbb.log"
        formatter = "default"

        [loggers.bbb]
        level = "DEBUG"
        handlers = ["bbb"]

        [loggers.b3desk]
        level = "INFO"
        handlers = ["wsgi"]

        [root]
        level = "INFO"
        handlers = ["wsgi"]
```