### PR TITLE
Personnalisation des claims OIDC

### DIFF
--- a/web/b3desk/endpoints/api.py
+++ b/web/b3desk/endpoints/api.py
@@ -15,7 +15,7 @@ bp = Blueprint("api", __name__)
 
 @bp.route("/api/meetings")
 @check_oidc_connection(auth)
-@auth.token_auth("default", scopes_required=["profile", "email"])
+@auth.token_auth("default", scopes_required=["openid"])
 def api_meetings():
     """Return all non-shadow meetings for the authenticated user via API."""
     client = auth.clients["default"]
@@ -56,7 +56,7 @@ def api_meetings():
 
 @bp.route("/api/shadow-meeting")
 @check_oidc_connection(auth)
-@auth.token_auth("default", scopes_required=["profile", "email"])
+@auth.token_auth("default", scopes_required=["openid"])
 def shadow_meeting():
     """Get or create the shadow meeting for the authenticated user via API."""
     client = auth.clients["default"]

--- a/web/b3desk/models/users.py
+++ b/web/b3desk/models/users.py
@@ -26,10 +26,13 @@ def get_or_create_user(user_info):
 
     Updates user information if any fields have changed and saves to database.
     """
-    given_name = user_info["given_name"]
-    family_name = user_info["family_name"]
-    preferred_username = user_info.get("preferred_username")
-    email = user_info["email"].lower()
+    mapping = current_app.config["OIDC_CLAIMS_MAPPING"]
+    given_name = user_info.get(mapping.get("given_name", "given_name"), "")
+    family_name = user_info.get(mapping.get("family_name", "family_name"), "")
+    preferred_username = user_info.get(
+        mapping.get("preferred_username", "preferred_username")
+    )
+    email = user_info[mapping.get("email", "email")].lower()
 
     user = db.session.query(User).filter(User.email == email).first()
 

--- a/web/b3desk/session.py
+++ b/web/b3desk/session.py
@@ -17,8 +17,11 @@ def get_authenticated_attendee_fullname():
     """Extract and return full name from authenticated attendee session."""
     attendee_session = UserSession(session)
     attendee_info = attendee_session.userinfo
-    given_name = attendee_info.get("given_name", "").title()
-    family_name = attendee_info.get("family_name", "").title()
+    mapping = current_app.config["OIDC_ATTENDEE_CLAIMS_MAPPING"]
+    given_name = attendee_info.get(mapping.get("given_name", "given_name"), "").title()
+    family_name = attendee_info.get(
+        mapping.get("family_name", "family_name"), ""
+    ).title()
     return f"{given_name} {family_name}".strip()
 
 

--- a/web/b3desk/settings.py
+++ b/web/b3desk/settings.py
@@ -354,8 +354,26 @@ class MainSettings(BaseSettings):
     https://flask-pyoidc.readthedocs.io/en/latest/api.html?highlight=userinfo_http_method#flask_pyoidc.provider_configuration.ProviderConfiguration
     """
 
-    OIDC_INFO_REQUESTED_FIELDS: list[str] = ["email", "given_name", "family_name"]
-    """Probablement un relicat de flask-oidc, semble inutilisé."""
+    OIDC_CLAIMS_MAPPING: dict[str, str] = {}
+    """Correspondance entre les champs utilisateur de B3Desk (clés) et les
+    claims renvoyés par le serveur d’identité (valeurs).
+
+    Permet d’adapter B3Desk à des serveurs OIDC qui n’utilisent pas les
+    claims standards, par exemple ProConnect où le nom de famille est
+    renvoyé dans le claim ``usual_name`` plutôt que ``family_name``.
+
+    Les champs utilisateurs supportés sont ``given_name``, ``family_name``,
+    ``email`` et ``preferred_username``. Tout champ absent de la
+    configuration est lu directement depuis le claim de même nom.
+
+    Si laissé vide (valeur par défaut), aucun mapping n’est appliqué et
+    les claims sont lus tels quels.
+
+    .. code-block:: shell
+        :caption: Exemple en variable d’environnement
+
+        OIDC_CLAIMS_MAPPING='{"given_name":"given_name","family_name":"usual_name","email":"email"}'
+    """
 
     OIDC_ISSUER: str | None = None
     """URL du serveur d’identité des organisateurs de réunion.
@@ -471,6 +489,19 @@ class MainSettings(BaseSettings):
     Plus d’infos sur https://flask-pyoidc.readthedocs.io/en/latest/api.html#module-flask_pyoidc.provider_configuration
     """
 
+    OIDC_ATTENDEE_CLAIMS_MAPPING: dict[str, str] = {}
+    """Correspondance entre les champs utilisateur de B3Desk (clés) et les
+    claims renvoyés par le serveur d’identité des participants authentifiés
+    (valeurs).
+
+    Si non renseigné, prend la valeur de ``OIDC_CLAIMS_MAPPING``.
+
+    .. code-block:: shell
+        :caption: Exemple en variable d’environnement
+
+        OIDC_ATTENDEE_CLAIMS_MAPPING='{"given_name":"given_name","family_name":"usual_name"}'
+    """
+
     SECONDARY_IDENTITY_PROVIDER_ENABLED: bool | None = False
     """Indique si un second serveur d'identité pour la connection a un
     Nextcloud est activée.
@@ -550,6 +581,13 @@ class MainSettings(BaseSettings):
     ) -> str:
         """Return OIDC_SCOPES if attendee scopes are not specified."""
         return attendee_scopes or info.data.get("OIDC_SCOPES")
+
+    @field_validator("OIDC_ATTENDEE_CLAIMS_MAPPING")
+    def get_attendee_claims_mapping(
+        cls, attendee_claims_mapping: dict[str, str], info: ValidationInfo
+    ) -> dict[str, str]:
+        """Return OIDC_CLAIMS_MAPPING if attendee claims mapping is not specified."""
+        return attendee_claims_mapping or info.data.get("OIDC_CLAIMS_MAPPING") or {}
 
     DOCUMENTATION_LINK_URL: str | None = None
     """Surcharge l’adresse de la page de documentation si renseigné."""

--- a/web/translations/messages.pot
+++ b/web/translations/messages.pot
@@ -220,27 +220,27 @@ msgstr ""
 msgid "Ajout d'utilisateur"
 msgstr ""
 
-#: web/b3desk/settings.py:619 web/b3desk/templates/meeting/list.html:4
+#: web/b3desk/settings.py:657 web/b3desk/templates/meeting/list.html:4
 msgid "Mes salles de réunion"
 msgstr ""
 
-#: web/b3desk/settings.py:623
+#: web/b3desk/settings.py:661
 msgid "Invitation à une réunion en ligne immédiate du Webinaire de l’Etat"
 msgstr ""
 
-#: web/b3desk/settings.py:636
+#: web/b3desk/settings.py:674
 msgid "Réunion improvisée"
 msgstr ""
 
-#: web/b3desk/settings.py:639
+#: web/b3desk/settings.py:677
 msgid " Lien Modérateur  "
 msgstr ""
 
-#: web/b3desk/settings.py:642
+#: web/b3desk/settings.py:680
 msgid " Lien Participant  "
 msgstr ""
 
-#: web/b3desk/settings.py:646
+#: web/b3desk/settings.py:684
 msgid ""
 "Bienvenue aux modérateurs. Pour inviter quelqu'un à cette réunion, "
 "envoyez-lui l'un de ces liens :"


### PR DESCRIPTION
Rajoute un paramètre de conf `OIDC_CLAIMS_MAPPING` qui permet de mapper les claims standards à des claims custom, par exemple pour proconnect.

```env
OIDC_SCOPES="openid,uid,idp_id,email,given_name,usual_name"
OIDC_CLAIMS_MAPPING='{"given_name":"given_name","family_name":"usual_name","email":"email"}'
```

fixes #353