### PR TITLE
Augmentation du nombre de délégataires par défaut, amélioration des messages d'erreur sur l'interface délégataires

### DIFF
--- a/web/b3desk/endpoints/meetings.py
+++ b/web/b3desk/endpoints/meetings.py
@@ -371,20 +371,16 @@ def manage_delegation(meeting: Meeting, user: User):
         )
 
     data = form.search.data.lower()
-    new_delegate = (
-        db.session.query(User)
-        .filter(
-            User.email == data,
-            user.email != User.email,
-        )
-        .first()
-    )
+    new_delegate = db.session.query(User).filter(User.email == data).first()
 
     if new_delegate is None:
         flash(_("L'utilisateur recherché n'existe pas"), "error")
 
     elif new_delegate in meeting.get_all_delegates:
         flash(_("L'utilisateur est déjà délégataire"), "warning")
+
+    elif data == meeting.owner.email:
+        flash(_("Cet utilisateur est le propriétaire"), "warning")
 
     elif (
         len(meeting.get_all_delegates)

--- a/web/b3desk/settings.py
+++ b/web/b3desk/settings.py
@@ -930,7 +930,7 @@ class MainSettings(BaseSettings):
     Number of attempts to enter the visio-code before submitting a captcha
     """
 
-    MAXIMUM_MEETING_DELEGATES: int | None = 1
+    MAXIMUM_MEETING_DELEGATES: int | None = 15
     """ Maximum meeting delegates
 
     Maximum number of delegates for one meeting

--- a/web/tests/meeting/test_delegated_meetings.py
+++ b/web/tests/meeting/test_delegated_meetings.py
@@ -239,7 +239,7 @@ def test_owner_cannot_add_himself_as_delegate(
     form = response.form
     form["search"] = "alice@domain.tld"
     response = form.submit()
-    assert ("error", "L'utilisateur recherché n'existe pas") in response.flashes
+    assert ("warning", "Cet utilisateur est le propriétaire") in response.flashes
     assert meeting.get_all_delegates == []
 
 

--- a/web/translations/messages.pot
+++ b/web/translations/messages.pot
@@ -379,27 +379,31 @@ msgstr ""
 msgid "Impossible de supprimer cette vidéo : %(code)s, %(message)s"
 msgstr ""
 
-#: web/b3desk/endpoints/meetings.py:384
+#: web/b3desk/endpoints/meetings.py:377
 msgid "L'utilisateur recherché n'existe pas"
 msgstr ""
 
-#: web/b3desk/endpoints/meetings.py:387
+#: web/b3desk/endpoints/meetings.py:380
 msgid "L'utilisateur est déjà délégataire"
 msgstr ""
 
-#: web/b3desk/endpoints/meetings.py:394
+#: web/b3desk/endpoints/meetings.py:383
+msgid "Cet utilisateur est le propriétaire"
+msgstr ""
+
+#: web/b3desk/endpoints/meetings.py:390
 msgid "Cette réunion ne peut plus recevoir de nouvelle délégation"
 msgstr ""
 
-#: web/b3desk/endpoints/meetings.py:407
+#: web/b3desk/endpoints/meetings.py:403
 msgid "L'utilisateur a été ajouté aux délégataires"
 msgstr ""
 
-#: web/b3desk/endpoints/meetings.py:428
+#: web/b3desk/endpoints/meetings.py:424
 msgid "L'utilisateur ne fait pas partie des délégataires"
 msgstr ""
 
-#: web/b3desk/endpoints/meetings.py:435
+#: web/b3desk/endpoints/meetings.py:431
 msgid "L'utilisateur a été retiré des délégataires"
 msgstr ""
 


### PR DESCRIPTION
### CHANGES
- setting `MAXIMUM_MEETING_DELEGATES` is 15 and not 1
- if new delegate is meeting owner : specific flash message (useful for admin mode)