### PR TITLE
Menu de sélection de langue

### DIFF
--- a/web/b3desk/__init__.py
+++ b/web/b3desk/__init__.py
@@ -11,13 +11,16 @@
 from logging.config import dictConfig
 from logging.config import fileConfig
 from pathlib import Path
+from urllib.parse import urlencode
 
+from babel import Locale
 from flask import Flask
 from flask import redirect
 from flask import render_template
 from flask import request
 from flask import url_for
 from flask_babel import Babel
+from flask_babel import get_locale
 from flask_caching import Cache
 from flask_migrate import Migrate
 from flask_pyoidc import OIDCAuthentication
@@ -34,7 +37,7 @@ from .utils import model_converter
 
 __version__ = "1.6.4dev"
 
-LANGUAGES = ["en", "fr"]
+LANGUAGES = ["fr", "en"]
 
 babel = Babel()
 cache = Cache()
@@ -178,7 +181,8 @@ def setup_i18n(app):
     def locale_selector():
         if request.args.get("lang") in LANGUAGES:
             session["lang"] = request.args["lang"]
-        lang = session.get("lang") if session.get("lang") in LANGUAGES else "fr"
+        default = app.config["BABEL_DEFAULT_LOCALE"]
+        lang = session.get("lang") if session.get("lang") in LANGUAGES else default
         if lang == "fr" and app.config.get("MEETING_LOCALE_VARIANT"):
             return f"fr@{app.config['MEETING_LOCALE_VARIANT']}"
         return lang
@@ -211,8 +215,18 @@ def setup_jinja(app):
     if app.debug or app.testing:
         app.jinja_env.undefined = StrictUndefined
 
+    def lang_url(code):
+        args = request.args.to_dict(flat=True)
+        args["lang"] = code
+        return f"{request.path}?{urlencode(args)}"
+
+    def language_name(code):
+        name = Locale.parse(code).display_name
+        return name[:1].upper() + name[1:]
+
     @app.context_processor
     def global_processor():
+        locale = get_locale()
         return {
             "debug": app.debug,
             "config": app.config,
@@ -222,6 +236,11 @@ def setup_jinja(app):
             "is_rie": is_rie(),
             "version": __version__,
             "LANGUAGES": LANGUAGES,
+            "current_lang": locale.language
+            if locale
+            else app.config["BABEL_DEFAULT_LOCALE"],
+            "lang_url": lang_url,
+            "language_name": language_name,
             "Role": Role,
         }
 

--- a/web/b3desk/settings.py
+++ b/web/b3desk/settings.py
@@ -253,6 +253,9 @@ class MainSettings(BaseSettings):
     https://python-babel.github.io/flask-babel/#configuration
     """
 
+    BABEL_DEFAULT_LOCALE: str = "fr"
+    """La langue utilisée par défaut lorsque l’utilisateur n’en a pas choisi."""
+
     MAX_MEETINGS_PER_USER: int = 50
     """Le nombre maximum de séminaires que peut créer un utilisateur."""
 

--- a/web/b3desk/templates/header-lasuite.html
+++ b/web/b3desk/templates/header-lasuite.html
@@ -36,6 +36,7 @@
                         >
                             {% trans %}Les services de La Suite numérique{% endtrans %}
                         </button>
+                        {% include 'language-selector.html' %}
                     </div>
                 </div>
             </div>

--- a/web/b3desk/templates/language-selector.html
+++ b/web/b3desk/templates/language-selector.html
@@ -1,0 +1,30 @@
+<nav role="navigation" class="fr-translate fr-nav">
+    <div class="fr-nav__item">
+        <button
+            aria-controls="language-selector"
+            aria-expanded="false"
+            title="{% trans %}Sélectionner une langue{% endtrans %}"
+            type="button"
+            class="fr-translate__btn fr-btn fr-btn--tertiary"
+        >
+            {{ current_lang.upper() }}<span class="fr-hidden-lg">&nbsp;- {{ language_name(current_lang) }}</span>
+        </button>
+        <div class="fr-collapse fr-translate__menu fr-menu" id="language-selector">
+            <ul class="fr-menu__list">
+                {% for code in LANGUAGES %}
+                    <li>
+                        <a
+                            class="fr-translate__language fr-nav__link"
+                            href="{{ lang_url(code) }}"
+                            hreflang="{{ code }}"
+                            lang="{{ code }}"
+                            {% if code == current_lang %}aria-current="true"{% endif %}
+                        >
+                            {{ code.upper() }} - {{ language_name(code) }}
+                        </a>
+                    </li>
+                {% endfor %}
+            </ul>
+        </div>
+    </div>
+</nav>

--- a/web/b3desk/templates/layout.html
+++ b/web/b3desk/templates/layout.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="fr">
+<html lang="{{ current_lang }}">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/web/b3desk/templates/meeting/file_picker.html
+++ b/web/b3desk/templates/meeting/file_picker.html
@@ -15,7 +15,7 @@
     <script src="{{ url_for('static', filename='js/file_picker.js')}}"></script>
 {% else %}
     <!doctype html>
-    <html lang="fr">
+    <html lang="{{ current_lang }}">
         <head>
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/web/b3desk/templates/static-layout.html
+++ b/web/b3desk/templates/static-layout.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="fr">
+<html lang="{{ current_lang }}">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/web/b3desk/templates/tools.html
+++ b/web/b3desk/templates/tools.html
@@ -2,12 +2,6 @@
     <div class="fr-header__tools-links">
         <ul class="fr-btns-group">
             <li>
-                {% for language in LANGUAGES %}
-                    <a href="?lang={{ language }}" class="fr-btn">{{ language}}</a>
-                {% endfor %}
-            </li>
-
-            <li>
                 <a class="fr-btn" href="{{ url_for("public.faq") }}">
                     <span aria-hidden="true" class="ri-information-line fr-mr-1w"></span>
                     {% trans %}Modalités d'accès{% endtrans %}
@@ -60,5 +54,6 @@
                 </li>
             {% endif %}
         </ul>
+        {% include 'language-selector.html' %}
     </div>
 </div>

--- a/web/tests/test_admin.py
+++ b/web/tests/test_admin.py
@@ -192,7 +192,7 @@ def test_research_bar_with_visio_code_in_meeting_list_in_admin_page(
     res = form.submit()
     assert res.text.count("Réunion silencieuse (shadow_meeting)") == 1
     assert res.text.count("922222222") == 0
-    assert res.text.count("511111111") == 2
+    assert res.pyquery("#meetings").text().count("511111111") == 1
     assert res.text.count("911111111") == 0
     assert res.text.count("911111112") == 0
     assert res.text.count("911111113") == 0

--- a/web/tests/test_default.py
+++ b/web/tests/test_default.py
@@ -113,6 +113,22 @@ def test_change_language_rejects_invalid_locales(app):
     assert res.session["lang"] == "fr"
 
 
+def test_language_selector_renders_active_language(app):
+    """Test that the DSFR language selector reflects the active language."""
+    client_app = TestApp(app)
+
+    res = client_app.get("/faq?lang=en", status=200)
+    assert '<html lang="en">' in res.text
+    assert 'class="fr-translate fr-nav"' in res.text
+    assert 'EN<span class="fr-hidden-lg">' in res.text
+    assert 'hreflang="en"' in res.text and 'hreflang="fr"' in res.text
+    assert 'aria-current="true"' in res.text
+
+    res = client_app.get("/faq?lang=fr", status=200)
+    assert '<html lang="fr">' in res.text
+    assert 'FR<span class="fr-hidden-lg">' in res.text
+
+
 def test_faq__anonymous_user(client_app):
     """Test that FAQ page displays without user name for anonymous users."""
     response = client_app.get("/faq", status=200)

--- a/web/translations/en/LC_MESSAGES/messages.po
+++ b/web/translations/en/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 10:41+0200\n"
+"POT-Creation-Date: 2026-06-15 17:26+0200\n"
 "PO-Revision-Date: 2026-05-05 10:03+0000\n"
 "Last-Translator: Éloi Rivard <eloi.rivard@nubla.fr>\n"
 "Language: en\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: web/b3desk/__init__.py:291 web/b3desk/endpoints/meeting_files.py:123
+#: web/b3desk/__init__.py:310 web/b3desk/endpoints/meeting_files.py:123
 #: web/b3desk/endpoints/meeting_files.py:182
 #: web/b3desk/endpoints/meeting_files.py:287
 #: web/b3desk/endpoints/meeting_files.py:477
@@ -41,7 +41,7 @@ msgid "Le texte est trop long"
 msgstr "The text is too long"
 
 #: web/b3desk/forms.py:51 web/b3desk/forms.py:106
-#: web/b3desk/templates/admin/selected_meeting.html:243
+#: web/b3desk/templates/admin/meeting_infos.html:235
 msgid "Salle d'attente"
 msgstr ""
 
@@ -66,7 +66,7 @@ msgstr ""
 msgid "Ma réunion"
 msgstr ""
 
-#: web/b3desk/forms.py:77 web/b3desk/templates/admin/selected_meeting.html:147
+#: web/b3desk/forms.py:77 web/b3desk/templates/admin/meeting_infos.html:148
 msgid "Texte de bienvenue"
 msgstr ""
 
@@ -81,7 +81,7 @@ msgstr ""
 msgid "Bienvenue dans cette réunion %(meeting_name)s."
 msgstr ""
 
-#: web/b3desk/forms.py:89 web/b3desk/templates/admin/selected_meeting.html:122
+#: web/b3desk/forms.py:89 web/b3desk/templates/admin/meeting_infos.html:123
 msgid "Nombre maximal de participants"
 msgstr ""
 
@@ -89,7 +89,7 @@ msgstr ""
 msgid "Limitez vos salons à 350 personnes pour plus de confort."
 msgstr ""
 
-#: web/b3desk/forms.py:94 web/b3desk/templates/admin/selected_meeting.html:139
+#: web/b3desk/forms.py:94 web/b3desk/templates/admin/meeting_infos.html:140
 msgid "Durée maximale (minutes)"
 msgstr ""
 
@@ -99,7 +99,7 @@ msgid ""
 " 120, 3h = 180, 4h = 240."
 msgstr ""
 
-#: web/b3desk/forms.py:113 web/b3desk/templates/admin/selected_meeting.html:180
+#: web/b3desk/forms.py:113 web/b3desk/templates/admin/meeting_infos.html:179
 msgid "Caméras visibles par les modérateurs uniquement"
 msgstr ""
 
@@ -109,7 +109,7 @@ msgid ""
 "participants quand cette option est activée."
 msgstr ""
 
-#: web/b3desk/forms.py:120 web/b3desk/templates/admin/selected_meeting.html:189
+#: web/b3desk/forms.py:120 web/b3desk/templates/admin/meeting_infos.html:187
 msgid "Participants muets à leur arrivée"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgid ""
 "leur micro fermé, pour un démarrage de réunion plus calme."
 msgstr ""
 
-#: web/b3desk/forms.py:127 web/b3desk/templates/admin/selected_meeting.html:198
+#: web/b3desk/forms.py:127 web/b3desk/templates/admin/meeting_infos.html:195
 msgid "Caméras des participants"
 msgstr ""
 
@@ -129,7 +129,7 @@ msgid ""
 "participants."
 msgstr ""
 
-#: web/b3desk/forms.py:135 web/b3desk/templates/admin/selected_meeting.html:207
+#: web/b3desk/forms.py:135 web/b3desk/templates/admin/meeting_infos.html:203
 msgid "Micros des participants"
 msgstr ""
 
@@ -139,19 +139,19 @@ msgid ""
 "participants."
 msgstr ""
 
-#: web/b3desk/forms.py:143 web/b3desk/templates/admin/selected_meeting.html:216
+#: web/b3desk/forms.py:143 web/b3desk/templates/admin/meeting_infos.html:211
 msgid "Discussions privées"
 msgstr ""
 
-#: web/b3desk/forms.py:148 web/b3desk/templates/admin/selected_meeting.html:225
+#: web/b3desk/forms.py:148 web/b3desk/templates/admin/meeting_infos.html:219
 msgid "Discussion publique (tchat)"
 msgstr ""
 
-#: web/b3desk/forms.py:153 web/b3desk/templates/admin/selected_meeting.html:234
+#: web/b3desk/forms.py:153 web/b3desk/templates/admin/meeting_infos.html:227
 msgid "Prise de note collaborative"
 msgstr ""
 
-#: web/b3desk/forms.py:158 web/b3desk/templates/admin/selected_meeting.html:155
+#: web/b3desk/forms.py:158 web/b3desk/templates/admin/meeting_infos.html:156
 msgid "Message à l'attention des modérateurs"
 msgstr ""
 
@@ -167,7 +167,7 @@ msgstr ""
 msgid "Le message est trop long"
 msgstr ""
 
-#: web/b3desk/forms.py:171 web/b3desk/templates/admin/selected_meeting.html:130
+#: web/b3desk/forms.py:171 web/b3desk/templates/admin/meeting_infos.html:131
 msgid "Url de redirection après la réunion"
 msgstr ""
 
@@ -183,7 +183,7 @@ msgstr ""
 msgid "Renouveler le lien participants"
 msgstr ""
 
-#: web/b3desk/forms.py:196 web/b3desk/templates/admin/selected_meeting.html:106
+#: web/b3desk/forms.py:196 web/b3desk/templates/admin/meeting_infos.html:107
 msgid "PIN"
 msgstr ""
 
@@ -216,7 +216,7 @@ msgstr ""
 msgid "(utilisé dans le lien SIP)"
 msgstr ""
 
-#: web/b3desk/forms.py:234 web/b3desk/templates/admin/selected_meeting.html:172
+#: web/b3desk/forms.py:234 web/b3desk/templates/admin/meeting_infos.html:172
 msgid "Enregistrement manuel"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "Vous pouvez lancer ou arrêter à tout moment l'enregistrement de la salle."
 msgstr ""
 
-#: web/b3desk/forms.py:241 web/b3desk/templates/admin/selected_meeting.html:163
+#: web/b3desk/forms.py:241 web/b3desk/templates/admin/meeting_infos.html:164
 msgid "Enregistrement automatique"
 msgstr ""
 
@@ -242,35 +242,35 @@ msgstr ""
 msgid "Ajout d'utilisateur"
 msgstr ""
 
-#: web/b3desk/forms.py:267 web/b3desk/templates/admin/users.html:20
+#: web/b3desk/forms.py:267 web/b3desk/templates/admin/users.html:19
 msgid "Rechercher un utilisateur"
 msgstr ""
 
-#: web/b3desk/forms.py:274 web/b3desk/templates/admin/meetings.html:20
+#: web/b3desk/forms.py:274 web/b3desk/templates/admin/meetings.html:19
 msgid "Rechercher une réunion"
 msgstr ""
 
-#: web/b3desk/settings.py:657 web/b3desk/templates/meeting/list.html:4
+#: web/b3desk/settings.py:660 web/b3desk/templates/meeting/list.html:4
 msgid "Mes salles de réunion"
 msgstr ""
 
-#: web/b3desk/settings.py:661
+#: web/b3desk/settings.py:664
 msgid "Invitation à une réunion en ligne immédiate du Webinaire de l’Etat"
 msgstr ""
 
-#: web/b3desk/settings.py:674
+#: web/b3desk/settings.py:677
 msgid "Réunion improvisée"
 msgstr ""
 
-#: web/b3desk/settings.py:677
+#: web/b3desk/settings.py:680
 msgid " Lien Modérateur  "
 msgstr ""
 
-#: web/b3desk/settings.py:680
+#: web/b3desk/settings.py:683
 msgid " Lien Participant  "
 msgstr ""
 
-#: web/b3desk/settings.py:684
+#: web/b3desk/settings.py:687
 msgid ""
 "Bienvenue aux modérateurs. Pour inviter quelqu'un à cette réunion, "
 "envoyez-lui l'un de ces liens :"
@@ -464,7 +464,7 @@ msgstr ""
 #: web/b3desk/templates/brand.html:17 web/b3desk/templates/brand.html:19
 #: web/b3desk/templates/header-lasuite.html:35
 #: web/b3desk/templates/header-lasuite.html:37
-#: web/b3desk/templates/tools.html:48 web/b3desk/templates/tools.html:50
+#: web/b3desk/templates/tools.html:42 web/b3desk/templates/tools.html:44
 msgid "Les services de La Suite numérique"
 msgstr ""
 
@@ -817,24 +817,28 @@ msgstr ""
 msgid "Se connecter ou créer un compte"
 msgstr ""
 
-#: web/b3desk/templates/tools.html:13
+#: web/b3desk/templates/language-selector.html:6
+msgid "Sélectionner une langue"
+msgstr ""
+
+#: web/b3desk/templates/tools.html:7
 msgid "Modalités d'accès"
 msgstr ""
 
-#: web/b3desk/templates/tools.html:30
+#: web/b3desk/templates/tools.html:24
 msgid "Ouvrir la page d'administration"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:81
-#: web/b3desk/templates/tools.html:31
+#: web/b3desk/templates/admin/user_infos.html:81
+#: web/b3desk/templates/tools.html:25
 msgid "Admin"
 msgstr ""
 
-#: web/b3desk/templates/tools.html:39
+#: web/b3desk/templates/tools.html:33
 msgid "se déconnecter"
 msgstr ""
 
-#: web/b3desk/templates/meeting/join.html:42 web/b3desk/templates/tools.html:58
+#: web/b3desk/templates/meeting/join.html:42 web/b3desk/templates/tools.html:52
 msgid "S’identifier"
 msgstr ""
 
@@ -854,19 +858,71 @@ msgstr ""
 msgid "Réunions"
 msgstr ""
 
+#: web/b3desk/templates/admin/macros.html:3
+#: web/b3desk/templates/meeting/files.html:188
+#: web/b3desk/templates/meeting/files.html:191
+msgid "Oui"
+msgstr ""
+
+#: web/b3desk/templates/admin/macros.html:5
+#: web/b3desk/templates/meeting/files.html:188
+#: web/b3desk/templates/meeting/files.html:191
+msgid "Non"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:24
+#: web/b3desk/templates/meeting/form.html:56
+msgid "Modifier"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:29
+msgid "Voir le propriétaire"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:43
 #: web/b3desk/templates/admin/meeting_table.html:10
-#: web/b3desk/templates/admin/selected_meeting.html:31
-#: web/b3desk/templates/admin/selected_user.html:33
+#: web/b3desk/templates/admin/user_infos.html:33
 #: web/b3desk/templates/admin/user_table.html:10
 msgid "Identifiant"
 msgstr ""
 
+#: web/b3desk/templates/admin/meeting_infos.html:51
 #: web/b3desk/templates/admin/meeting_table.html:11
-#: web/b3desk/templates/admin/selected_meeting.html:39
-#: web/b3desk/templates/admin/selected_user.html:41
+#: web/b3desk/templates/admin/user_infos.html:41
 #: web/b3desk/templates/admin/user_table.html:11
 #: web/b3desk/templates/footer/donnees_personnelles.html:54
 msgid "Nom"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:59
+msgid "Propriétaire"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:67
+#: web/b3desk/templates/admin/meeting_table.html:34
+msgid "Réunion silencieuse (shadow_meeting)"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:75
+#: web/b3desk/templates/admin/user_infos.html:65
+msgid "Dernière connexion"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:83
+#: web/b3desk/templates/admin/user_infos.html:73
+msgid "Création"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:91
+msgid "Dernière modification"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:99
+msgid "n° de téléphone"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:115
+msgid "Code de connexion (visio_code)"
 msgstr ""
 
 #: web/b3desk/templates/admin/meeting_table.html:12
@@ -883,14 +939,23 @@ msgstr ""
 msgid "Éditer %(meeting_name)s"
 msgstr ""
 
-#: web/b3desk/templates/admin/meeting_table.html:34
-#: web/b3desk/templates/admin/selected_meeting.html:65
-msgid "Réunion silencieuse (shadow_meeting)"
-msgstr ""
-
-#: web/b3desk/templates/admin/meetings.html:26
+#: web/b3desk/templates/admin/meetings.html:25
 msgid "Aucune réunion ne correspond à cette recherche."
 msgstr ""
+
+#: web/b3desk/templates/admin/meetings.html:32
+#, python-format
+msgid "%(count)s réunion correspondant aux critères"
+msgid_plural "%(count)s réunions correspondant aux critères"
+msgstr[0] ""
+msgstr[1] ""
+
+#: web/b3desk/templates/admin/meetings.html:38
+#, python-format
+msgid "%(count)s réunion"
+msgid_plural "%(count)s réunions"
+msgstr[0] ""
+msgstr[1] ""
 
 #: web/b3desk/templates/admin/paging.html:7
 #: web/b3desk/templates/admin/paging.html:9
@@ -912,85 +977,39 @@ msgstr ""
 msgid "Dernière page"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_meeting.html:47
-msgid "Éditer la réunion"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:50
-#: web/b3desk/templates/admin/selected_meeting.html:51
-#: web/b3desk/templates/meeting/row.html:20
-#: web/b3desk/templates/meeting/row.html:54
-#, python-format
-msgid "Modifier %(meeting_name)s"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:57
-msgid "Propriétaire"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:74
-#: web/b3desk/templates/admin/selected_user.html:65
-msgid "Dernière connexion"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:82
-#: web/b3desk/templates/admin/selected_user.html:73
-msgid "Création"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:90
-msgid "Dernière modification"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:98
-msgid "n° de téléphone"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:114
-msgid "Code de connexion (visio_code)"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_user.html:49
+#: web/b3desk/templates/admin/user_infos.html:49
 #: web/b3desk/templates/admin/user_table.html:13
 msgid "Email"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:57
+#: web/b3desk/templates/admin/user_infos.html:57
 msgid "Alias"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:90
+#: web/b3desk/templates/admin/user_infos.html:89
 msgid "NC Locator"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:98
+#: web/b3desk/templates/admin/user_infos.html:97
 msgid "NC Login"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:106
+#: web/b3desk/templates/admin/user_infos.html:105
 msgid "NC Dernière connexion"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:120
+#: web/b3desk/templates/admin/user_infos.html:119
 #, python-format
 msgid "Liste des réunions de %(fullname)s"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:124
+#: web/b3desk/templates/admin/user_infos.html:123
 #, python-format
 msgid "%(fullname)s n'a pas créé de réunion."
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:127
+#: web/b3desk/templates/admin/user_infos.html:126
 msgid "Réunions déléguées"
-msgstr ""
-
-#: web/b3desk/templates/admin/true_false_display.html:2
-msgid "OUI"
-msgstr ""
-
-#: web/b3desk/templates/admin/true_false_display.html:4
-msgid "NON"
 msgstr ""
 
 #: web/b3desk/templates/admin/user_table.html:12
@@ -1003,9 +1022,23 @@ msgstr ""
 msgid "%(username)s infos"
 msgstr ""
 
-#: web/b3desk/templates/admin/users.html:26
+#: web/b3desk/templates/admin/users.html:25
 msgid "Aucun utilisateur ne correspond à cette recherche."
 msgstr ""
+
+#: web/b3desk/templates/admin/users.html:32
+#, python-format
+msgid "%(count)s utilisateur correspondant aux critères"
+msgid_plural "%(count)s utilisateurs correspondant aux critères"
+msgstr[0] ""
+msgstr[1] ""
+
+#: web/b3desk/templates/admin/users.html:38
+#, python-format
+msgid "%(count)s utilisateur"
+msgid_plural "%(count)s utilisateurs"
+msgstr[0] ""
+msgstr[1] ""
 
 #: web/b3desk/templates/errors/400.html:7
 msgid "Erreur 400"
@@ -2280,16 +2313,6 @@ msgstr ""
 msgid "Annuler"
 msgstr ""
 
-#: web/b3desk/templates/meeting/files.html:188
-#: web/b3desk/templates/meeting/files.html:191
-msgid "Oui"
-msgstr ""
-
-#: web/b3desk/templates/meeting/files.html:188
-#: web/b3desk/templates/meeting/files.html:191
-msgid "Non"
-msgstr ""
-
 #: web/b3desk/templates/meeting/files.html:213
 msgid "Aucun document de présentation n'est prévu pour cette réunion actuellement"
 msgstr ""
@@ -2302,10 +2325,6 @@ msgstr ""
 #: web/b3desk/templates/meeting/form.html:11
 #: web/b3desk/templates/meeting/form.html:13
 msgid "Désactivé"
-msgstr ""
-
-#: web/b3desk/templates/meeting/form.html:56
-msgid "Modifier"
 msgstr ""
 
 #: web/b3desk/templates/meeting/form.html:58
@@ -2590,6 +2609,12 @@ msgstr ""
 
 #: web/b3desk/templates/meeting/row.html:17
 msgid "Copier le lien Participant dans le presse-papiers"
+msgstr ""
+
+#: web/b3desk/templates/meeting/row.html:20
+#: web/b3desk/templates/meeting/row.html:54
+#, python-format
+msgid "Modifier %(meeting_name)s"
 msgstr ""
 
 #: web/b3desk/templates/meeting/row.html:22
@@ -6888,5 +6913,14 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Quitter la page d'administration"
+#~ msgstr ""
+
+#~ msgid "Éditer la réunion"
+#~ msgstr ""
+
+#~ msgid "OUI"
+#~ msgstr ""
+
+#~ msgid "NON"
 #~ msgstr ""
 

--- a/web/translations/fr/LC_MESSAGES/messages.po
+++ b/web/translations/fr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 10:41+0200\n"
+"POT-Creation-Date: 2026-06-15 17:26+0200\n"
 "PO-Revision-Date: 2022-04-29 15:10+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: web/b3desk/__init__.py:291 web/b3desk/endpoints/meeting_files.py:123
+#: web/b3desk/__init__.py:310 web/b3desk/endpoints/meeting_files.py:123
 #: web/b3desk/endpoints/meeting_files.py:182
 #: web/b3desk/endpoints/meeting_files.py:287
 #: web/b3desk/endpoints/meeting_files.py:477
@@ -40,7 +40,7 @@ msgid "Le texte est trop long"
 msgstr ""
 
 #: web/b3desk/forms.py:51 web/b3desk/forms.py:106
-#: web/b3desk/templates/admin/selected_meeting.html:243
+#: web/b3desk/templates/admin/meeting_infos.html:235
 msgid "Salle d'attente"
 msgstr ""
 
@@ -65,7 +65,7 @@ msgstr ""
 msgid "Ma réunion"
 msgstr ""
 
-#: web/b3desk/forms.py:77 web/b3desk/templates/admin/selected_meeting.html:147
+#: web/b3desk/forms.py:77 web/b3desk/templates/admin/meeting_infos.html:148
 msgid "Texte de bienvenue"
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "Bienvenue dans cette réunion %(meeting_name)s."
 msgstr ""
 
-#: web/b3desk/forms.py:89 web/b3desk/templates/admin/selected_meeting.html:122
+#: web/b3desk/forms.py:89 web/b3desk/templates/admin/meeting_infos.html:123
 msgid "Nombre maximal de participants"
 msgstr ""
 
@@ -88,7 +88,7 @@ msgstr ""
 msgid "Limitez vos salons à 350 personnes pour plus de confort."
 msgstr ""
 
-#: web/b3desk/forms.py:94 web/b3desk/templates/admin/selected_meeting.html:139
+#: web/b3desk/forms.py:94 web/b3desk/templates/admin/meeting_infos.html:140
 msgid "Durée maximale (minutes)"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgid ""
 " 120, 3h = 180, 4h = 240."
 msgstr ""
 
-#: web/b3desk/forms.py:113 web/b3desk/templates/admin/selected_meeting.html:180
+#: web/b3desk/forms.py:113 web/b3desk/templates/admin/meeting_infos.html:179
 msgid "Caméras visibles par les modérateurs uniquement"
 msgstr ""
 
@@ -108,7 +108,7 @@ msgid ""
 "participants quand cette option est activée."
 msgstr ""
 
-#: web/b3desk/forms.py:120 web/b3desk/templates/admin/selected_meeting.html:189
+#: web/b3desk/forms.py:120 web/b3desk/templates/admin/meeting_infos.html:187
 msgid "Participants muets à leur arrivée"
 msgstr ""
 
@@ -118,7 +118,7 @@ msgid ""
 "leur micro fermé, pour un démarrage de réunion plus calme."
 msgstr ""
 
-#: web/b3desk/forms.py:127 web/b3desk/templates/admin/selected_meeting.html:198
+#: web/b3desk/forms.py:127 web/b3desk/templates/admin/meeting_infos.html:195
 msgid "Caméras des participants"
 msgstr ""
 
@@ -128,7 +128,7 @@ msgid ""
 "participants."
 msgstr ""
 
-#: web/b3desk/forms.py:135 web/b3desk/templates/admin/selected_meeting.html:207
+#: web/b3desk/forms.py:135 web/b3desk/templates/admin/meeting_infos.html:203
 msgid "Micros des participants"
 msgstr ""
 
@@ -138,19 +138,19 @@ msgid ""
 "participants."
 msgstr ""
 
-#: web/b3desk/forms.py:143 web/b3desk/templates/admin/selected_meeting.html:216
+#: web/b3desk/forms.py:143 web/b3desk/templates/admin/meeting_infos.html:211
 msgid "Discussions privées"
 msgstr ""
 
-#: web/b3desk/forms.py:148 web/b3desk/templates/admin/selected_meeting.html:225
+#: web/b3desk/forms.py:148 web/b3desk/templates/admin/meeting_infos.html:219
 msgid "Discussion publique (tchat)"
 msgstr ""
 
-#: web/b3desk/forms.py:153 web/b3desk/templates/admin/selected_meeting.html:234
+#: web/b3desk/forms.py:153 web/b3desk/templates/admin/meeting_infos.html:227
 msgid "Prise de note collaborative"
 msgstr ""
 
-#: web/b3desk/forms.py:158 web/b3desk/templates/admin/selected_meeting.html:155
+#: web/b3desk/forms.py:158 web/b3desk/templates/admin/meeting_infos.html:156
 msgid "Message à l'attention des modérateurs"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Le message est trop long"
 msgstr ""
 
-#: web/b3desk/forms.py:171 web/b3desk/templates/admin/selected_meeting.html:130
+#: web/b3desk/forms.py:171 web/b3desk/templates/admin/meeting_infos.html:131
 msgid "Url de redirection après la réunion"
 msgstr ""
 
@@ -182,7 +182,7 @@ msgstr ""
 msgid "Renouveler le lien participants"
 msgstr ""
 
-#: web/b3desk/forms.py:196 web/b3desk/templates/admin/selected_meeting.html:106
+#: web/b3desk/forms.py:196 web/b3desk/templates/admin/meeting_infos.html:107
 msgid "PIN"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "(utilisé dans le lien SIP)"
 msgstr ""
 
-#: web/b3desk/forms.py:234 web/b3desk/templates/admin/selected_meeting.html:172
+#: web/b3desk/forms.py:234 web/b3desk/templates/admin/meeting_infos.html:172
 msgid "Enregistrement manuel"
 msgstr ""
 
@@ -223,7 +223,7 @@ msgstr ""
 msgid "Vous pouvez lancer ou arrêter à tout moment l'enregistrement de la salle."
 msgstr ""
 
-#: web/b3desk/forms.py:241 web/b3desk/templates/admin/selected_meeting.html:163
+#: web/b3desk/forms.py:241 web/b3desk/templates/admin/meeting_infos.html:164
 msgid "Enregistrement automatique"
 msgstr ""
 
@@ -241,35 +241,35 @@ msgstr ""
 msgid "Ajout d'utilisateur"
 msgstr ""
 
-#: web/b3desk/forms.py:267 web/b3desk/templates/admin/users.html:20
+#: web/b3desk/forms.py:267 web/b3desk/templates/admin/users.html:19
 msgid "Rechercher un utilisateur"
 msgstr ""
 
-#: web/b3desk/forms.py:274 web/b3desk/templates/admin/meetings.html:20
+#: web/b3desk/forms.py:274 web/b3desk/templates/admin/meetings.html:19
 msgid "Rechercher une réunion"
 msgstr ""
 
-#: web/b3desk/settings.py:657 web/b3desk/templates/meeting/list.html:4
+#: web/b3desk/settings.py:660 web/b3desk/templates/meeting/list.html:4
 msgid "Mes salles de réunion"
 msgstr ""
 
-#: web/b3desk/settings.py:661
+#: web/b3desk/settings.py:664
 msgid "Invitation à une réunion en ligne immédiate du Webinaire de l’Etat"
 msgstr ""
 
-#: web/b3desk/settings.py:674
+#: web/b3desk/settings.py:677
 msgid "Réunion improvisée"
 msgstr ""
 
-#: web/b3desk/settings.py:677
+#: web/b3desk/settings.py:680
 msgid " Lien Modérateur  "
 msgstr ""
 
-#: web/b3desk/settings.py:680
+#: web/b3desk/settings.py:683
 msgid " Lien Participant  "
 msgstr ""
 
-#: web/b3desk/settings.py:684
+#: web/b3desk/settings.py:687
 msgid ""
 "Bienvenue aux modérateurs. Pour inviter quelqu'un à cette réunion, "
 "envoyez-lui l'un de ces liens :"
@@ -463,7 +463,7 @@ msgstr ""
 #: web/b3desk/templates/brand.html:17 web/b3desk/templates/brand.html:19
 #: web/b3desk/templates/header-lasuite.html:35
 #: web/b3desk/templates/header-lasuite.html:37
-#: web/b3desk/templates/tools.html:48 web/b3desk/templates/tools.html:50
+#: web/b3desk/templates/tools.html:42 web/b3desk/templates/tools.html:44
 msgid "Les services de La Suite numérique"
 msgstr ""
 
@@ -816,24 +816,28 @@ msgstr ""
 msgid "Se connecter ou créer un compte"
 msgstr ""
 
-#: web/b3desk/templates/tools.html:13
+#: web/b3desk/templates/language-selector.html:6
+msgid "Sélectionner une langue"
+msgstr ""
+
+#: web/b3desk/templates/tools.html:7
 msgid "Modalités d'accès"
 msgstr ""
 
-#: web/b3desk/templates/tools.html:30
+#: web/b3desk/templates/tools.html:24
 msgid "Ouvrir la page d'administration"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:81
-#: web/b3desk/templates/tools.html:31
+#: web/b3desk/templates/admin/user_infos.html:81
+#: web/b3desk/templates/tools.html:25
 msgid "Admin"
 msgstr ""
 
-#: web/b3desk/templates/tools.html:39
+#: web/b3desk/templates/tools.html:33
 msgid "se déconnecter"
 msgstr ""
 
-#: web/b3desk/templates/meeting/join.html:42 web/b3desk/templates/tools.html:58
+#: web/b3desk/templates/meeting/join.html:42 web/b3desk/templates/tools.html:52
 msgid "S’identifier"
 msgstr ""
 
@@ -853,19 +857,71 @@ msgstr ""
 msgid "Réunions"
 msgstr ""
 
+#: web/b3desk/templates/admin/macros.html:3
+#: web/b3desk/templates/meeting/files.html:188
+#: web/b3desk/templates/meeting/files.html:191
+msgid "Oui"
+msgstr ""
+
+#: web/b3desk/templates/admin/macros.html:5
+#: web/b3desk/templates/meeting/files.html:188
+#: web/b3desk/templates/meeting/files.html:191
+msgid "Non"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:24
+#: web/b3desk/templates/meeting/form.html:56
+msgid "Modifier"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:29
+msgid "Voir le propriétaire"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:43
 #: web/b3desk/templates/admin/meeting_table.html:10
-#: web/b3desk/templates/admin/selected_meeting.html:31
-#: web/b3desk/templates/admin/selected_user.html:33
+#: web/b3desk/templates/admin/user_infos.html:33
 #: web/b3desk/templates/admin/user_table.html:10
 msgid "Identifiant"
 msgstr ""
 
+#: web/b3desk/templates/admin/meeting_infos.html:51
 #: web/b3desk/templates/admin/meeting_table.html:11
-#: web/b3desk/templates/admin/selected_meeting.html:39
-#: web/b3desk/templates/admin/selected_user.html:41
+#: web/b3desk/templates/admin/user_infos.html:41
 #: web/b3desk/templates/admin/user_table.html:11
 #: web/b3desk/templates/footer/donnees_personnelles.html:54
 msgid "Nom"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:59
+msgid "Propriétaire"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:67
+#: web/b3desk/templates/admin/meeting_table.html:34
+msgid "Réunion silencieuse (shadow_meeting)"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:75
+#: web/b3desk/templates/admin/user_infos.html:65
+msgid "Dernière connexion"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:83
+#: web/b3desk/templates/admin/user_infos.html:73
+msgid "Création"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:91
+msgid "Dernière modification"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:99
+msgid "n° de téléphone"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:115
+msgid "Code de connexion (visio_code)"
 msgstr ""
 
 #: web/b3desk/templates/admin/meeting_table.html:12
@@ -882,14 +938,23 @@ msgstr ""
 msgid "Éditer %(meeting_name)s"
 msgstr ""
 
-#: web/b3desk/templates/admin/meeting_table.html:34
-#: web/b3desk/templates/admin/selected_meeting.html:65
-msgid "Réunion silencieuse (shadow_meeting)"
-msgstr ""
-
-#: web/b3desk/templates/admin/meetings.html:26
+#: web/b3desk/templates/admin/meetings.html:25
 msgid "Aucune réunion ne correspond à cette recherche."
 msgstr ""
+
+#: web/b3desk/templates/admin/meetings.html:32
+#, python-format
+msgid "%(count)s réunion correspondant aux critères"
+msgid_plural "%(count)s réunions correspondant aux critères"
+msgstr[0] ""
+msgstr[1] ""
+
+#: web/b3desk/templates/admin/meetings.html:38
+#, python-format
+msgid "%(count)s réunion"
+msgid_plural "%(count)s réunions"
+msgstr[0] ""
+msgstr[1] ""
 
 #: web/b3desk/templates/admin/paging.html:7
 #: web/b3desk/templates/admin/paging.html:9
@@ -911,85 +976,39 @@ msgstr ""
 msgid "Dernière page"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_meeting.html:47
-msgid "Éditer la réunion"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:50
-#: web/b3desk/templates/admin/selected_meeting.html:51
-#: web/b3desk/templates/meeting/row.html:20
-#: web/b3desk/templates/meeting/row.html:54
-#, python-format
-msgid "Modifier %(meeting_name)s"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:57
-msgid "Propriétaire"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:74
-#: web/b3desk/templates/admin/selected_user.html:65
-msgid "Dernière connexion"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:82
-#: web/b3desk/templates/admin/selected_user.html:73
-msgid "Création"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:90
-msgid "Dernière modification"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:98
-msgid "n° de téléphone"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:114
-msgid "Code de connexion (visio_code)"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_user.html:49
+#: web/b3desk/templates/admin/user_infos.html:49
 #: web/b3desk/templates/admin/user_table.html:13
 msgid "Email"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:57
+#: web/b3desk/templates/admin/user_infos.html:57
 msgid "Alias"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:90
+#: web/b3desk/templates/admin/user_infos.html:89
 msgid "NC Locator"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:98
+#: web/b3desk/templates/admin/user_infos.html:97
 msgid "NC Login"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:106
+#: web/b3desk/templates/admin/user_infos.html:105
 msgid "NC Dernière connexion"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:120
+#: web/b3desk/templates/admin/user_infos.html:119
 #, python-format
 msgid "Liste des réunions de %(fullname)s"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:124
+#: web/b3desk/templates/admin/user_infos.html:123
 #, python-format
 msgid "%(fullname)s n'a pas créé de réunion."
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:127
+#: web/b3desk/templates/admin/user_infos.html:126
 msgid "Réunions déléguées"
-msgstr ""
-
-#: web/b3desk/templates/admin/true_false_display.html:2
-msgid "OUI"
-msgstr ""
-
-#: web/b3desk/templates/admin/true_false_display.html:4
-msgid "NON"
 msgstr ""
 
 #: web/b3desk/templates/admin/user_table.html:12
@@ -1002,9 +1021,23 @@ msgstr ""
 msgid "%(username)s infos"
 msgstr ""
 
-#: web/b3desk/templates/admin/users.html:26
+#: web/b3desk/templates/admin/users.html:25
 msgid "Aucun utilisateur ne correspond à cette recherche."
 msgstr ""
+
+#: web/b3desk/templates/admin/users.html:32
+#, python-format
+msgid "%(count)s utilisateur correspondant aux critères"
+msgid_plural "%(count)s utilisateurs correspondant aux critères"
+msgstr[0] ""
+msgstr[1] ""
+
+#: web/b3desk/templates/admin/users.html:38
+#, python-format
+msgid "%(count)s utilisateur"
+msgid_plural "%(count)s utilisateurs"
+msgstr[0] ""
+msgstr[1] ""
 
 #: web/b3desk/templates/errors/400.html:7
 msgid "Erreur 400"
@@ -2279,16 +2312,6 @@ msgstr ""
 msgid "Annuler"
 msgstr ""
 
-#: web/b3desk/templates/meeting/files.html:188
-#: web/b3desk/templates/meeting/files.html:191
-msgid "Oui"
-msgstr ""
-
-#: web/b3desk/templates/meeting/files.html:188
-#: web/b3desk/templates/meeting/files.html:191
-msgid "Non"
-msgstr ""
-
 #: web/b3desk/templates/meeting/files.html:213
 msgid "Aucun document de présentation n'est prévu pour cette réunion actuellement"
 msgstr ""
@@ -2301,10 +2324,6 @@ msgstr ""
 #: web/b3desk/templates/meeting/form.html:11
 #: web/b3desk/templates/meeting/form.html:13
 msgid "Désactivé"
-msgstr ""
-
-#: web/b3desk/templates/meeting/form.html:56
-msgid "Modifier"
 msgstr ""
 
 #: web/b3desk/templates/meeting/form.html:58
@@ -2589,6 +2608,12 @@ msgstr ""
 
 #: web/b3desk/templates/meeting/row.html:17
 msgid "Copier le lien Participant dans le presse-papiers"
+msgstr ""
+
+#: web/b3desk/templates/meeting/row.html:20
+#: web/b3desk/templates/meeting/row.html:54
+#, python-format
+msgid "Modifier %(meeting_name)s"
 msgstr ""
 
 #: web/b3desk/templates/meeting/row.html:22
@@ -6593,5 +6618,14 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Quitter la page d'administration"
+#~ msgstr ""
+
+#~ msgid "Éditer la réunion"
+#~ msgstr ""
+
+#~ msgid "OUI"
+#~ msgstr ""
+
+#~ msgid "NON"
 #~ msgstr ""
 

--- a/web/translations/fr@cours/LC_MESSAGES/messages.po
+++ b/web/translations/fr@cours/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 10:41+0200\n"
+"POT-Creation-Date: 2026-06-15 17:26+0200\n"
 "PO-Revision-Date: 2026-02-13 14:28+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr@cours\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: web/b3desk/__init__.py:291 web/b3desk/endpoints/meeting_files.py:123
+#: web/b3desk/__init__.py:310 web/b3desk/endpoints/meeting_files.py:123
 #: web/b3desk/endpoints/meeting_files.py:182
 #: web/b3desk/endpoints/meeting_files.py:287
 #: web/b3desk/endpoints/meeting_files.py:477
@@ -40,7 +40,7 @@ msgid "Le texte est trop long"
 msgstr ""
 
 #: web/b3desk/forms.py:51 web/b3desk/forms.py:106
-#: web/b3desk/templates/admin/selected_meeting.html:243
+#: web/b3desk/templates/admin/meeting_infos.html:235
 msgid "Salle d'attente"
 msgstr ""
 
@@ -68,7 +68,7 @@ msgstr ""
 msgid "Ma réunion"
 msgstr "Mon cours"
 
-#: web/b3desk/forms.py:77 web/b3desk/templates/admin/selected_meeting.html:147
+#: web/b3desk/forms.py:77 web/b3desk/templates/admin/meeting_infos.html:148
 msgid "Texte de bienvenue"
 msgstr ""
 
@@ -83,7 +83,7 @@ msgstr ""
 msgid "Bienvenue dans cette réunion %(meeting_name)s."
 msgstr "Bienvenue dans ce cours %(meeting_name)s."
 
-#: web/b3desk/forms.py:89 web/b3desk/templates/admin/selected_meeting.html:122
+#: web/b3desk/forms.py:89 web/b3desk/templates/admin/meeting_infos.html:123
 msgid "Nombre maximal de participants"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 msgid "Limitez vos salons à 350 personnes pour plus de confort."
 msgstr ""
 
-#: web/b3desk/forms.py:94 web/b3desk/templates/admin/selected_meeting.html:139
+#: web/b3desk/forms.py:94 web/b3desk/templates/admin/meeting_infos.html:140
 msgid "Durée maximale (minutes)"
 msgstr ""
 
@@ -103,7 +103,7 @@ msgstr ""
 "A l'issue de cette durée le cours stoppe automatiquement. 1h = 60, 2h = "
 "120, 3h = 180, 4h = 240."
 
-#: web/b3desk/forms.py:113 web/b3desk/templates/admin/selected_meeting.html:180
+#: web/b3desk/forms.py:113 web/b3desk/templates/admin/meeting_infos.html:179
 msgid "Caméras visibles par les modérateurs uniquement"
 msgstr ""
 
@@ -113,7 +113,7 @@ msgid ""
 "participants quand cette option est activée."
 msgstr ""
 
-#: web/b3desk/forms.py:120 web/b3desk/templates/admin/selected_meeting.html:189
+#: web/b3desk/forms.py:120 web/b3desk/templates/admin/meeting_infos.html:187
 msgid "Participants muets à leur arrivée"
 msgstr ""
 
@@ -125,7 +125,7 @@ msgstr ""
 "Vous pouvez choisir de faire arriver les participants dans la salle avec "
 "leur micro fermé, pour un démarrage de cours plus calme."
 
-#: web/b3desk/forms.py:127 web/b3desk/templates/admin/selected_meeting.html:198
+#: web/b3desk/forms.py:127 web/b3desk/templates/admin/meeting_infos.html:195
 msgid "Caméras des participants"
 msgstr ""
 
@@ -135,7 +135,7 @@ msgid ""
 "participants."
 msgstr ""
 
-#: web/b3desk/forms.py:135 web/b3desk/templates/admin/selected_meeting.html:207
+#: web/b3desk/forms.py:135 web/b3desk/templates/admin/meeting_infos.html:203
 msgid "Micros des participants"
 msgstr ""
 
@@ -145,19 +145,19 @@ msgid ""
 "participants."
 msgstr ""
 
-#: web/b3desk/forms.py:143 web/b3desk/templates/admin/selected_meeting.html:216
+#: web/b3desk/forms.py:143 web/b3desk/templates/admin/meeting_infos.html:211
 msgid "Discussions privées"
 msgstr ""
 
-#: web/b3desk/forms.py:148 web/b3desk/templates/admin/selected_meeting.html:225
+#: web/b3desk/forms.py:148 web/b3desk/templates/admin/meeting_infos.html:219
 msgid "Discussion publique (tchat)"
 msgstr ""
 
-#: web/b3desk/forms.py:153 web/b3desk/templates/admin/selected_meeting.html:234
+#: web/b3desk/forms.py:153 web/b3desk/templates/admin/meeting_infos.html:227
 msgid "Prise de note collaborative"
 msgstr ""
 
-#: web/b3desk/forms.py:158 web/b3desk/templates/admin/selected_meeting.html:155
+#: web/b3desk/forms.py:158 web/b3desk/templates/admin/meeting_infos.html:156
 msgid "Message à l'attention des modérateurs"
 msgstr ""
 
@@ -173,7 +173,7 @@ msgstr ""
 msgid "Le message est trop long"
 msgstr ""
 
-#: web/b3desk/forms.py:171 web/b3desk/templates/admin/selected_meeting.html:130
+#: web/b3desk/forms.py:171 web/b3desk/templates/admin/meeting_infos.html:131
 msgid "Url de redirection après la réunion"
 msgstr "Url de redirection après le cours"
 
@@ -189,7 +189,7 @@ msgstr ""
 msgid "Renouveler le lien participants"
 msgstr ""
 
-#: web/b3desk/forms.py:196 web/b3desk/templates/admin/selected_meeting.html:106
+#: web/b3desk/forms.py:196 web/b3desk/templates/admin/meeting_infos.html:107
 msgid "PIN"
 msgstr ""
 
@@ -222,7 +222,7 @@ msgstr "Code de connexion pour rejoindre le cours %(sip)s"
 msgid "(utilisé dans le lien SIP)"
 msgstr ""
 
-#: web/b3desk/forms.py:234 web/b3desk/templates/admin/selected_meeting.html:172
+#: web/b3desk/forms.py:234 web/b3desk/templates/admin/meeting_infos.html:172
 msgid "Enregistrement manuel"
 msgstr ""
 
@@ -230,7 +230,7 @@ msgstr ""
 msgid "Vous pouvez lancer ou arrêter à tout moment l'enregistrement de la salle."
 msgstr ""
 
-#: web/b3desk/forms.py:241 web/b3desk/templates/admin/selected_meeting.html:163
+#: web/b3desk/forms.py:241 web/b3desk/templates/admin/meeting_infos.html:164
 msgid "Enregistrement automatique"
 msgstr ""
 
@@ -248,36 +248,36 @@ msgstr ""
 msgid "Ajout d'utilisateur"
 msgstr ""
 
-#: web/b3desk/forms.py:267 web/b3desk/templates/admin/users.html:20
+#: web/b3desk/forms.py:267 web/b3desk/templates/admin/users.html:19
 msgid "Rechercher un utilisateur"
 msgstr ""
 
-#: web/b3desk/forms.py:274 web/b3desk/templates/admin/meetings.html:20
+#: web/b3desk/forms.py:274 web/b3desk/templates/admin/meetings.html:19
 #, fuzzy
 msgid "Rechercher une réunion"
 msgstr "Créer un cours"
 
-#: web/b3desk/settings.py:657 web/b3desk/templates/meeting/list.html:4
+#: web/b3desk/settings.py:660 web/b3desk/templates/meeting/list.html:4
 msgid "Mes salles de réunion"
 msgstr "Mes salles de cours"
 
-#: web/b3desk/settings.py:661
+#: web/b3desk/settings.py:664
 msgid "Invitation à une réunion en ligne immédiate du Webinaire de l’Etat"
 msgstr "Invitation à un cours en ligne immédiat du Webinaire de l’Etat"
 
-#: web/b3desk/settings.py:674
+#: web/b3desk/settings.py:677
 msgid "Réunion improvisée"
 msgstr "Cours improvisé"
 
-#: web/b3desk/settings.py:677
+#: web/b3desk/settings.py:680
 msgid " Lien Modérateur  "
 msgstr ""
 
-#: web/b3desk/settings.py:680
+#: web/b3desk/settings.py:683
 msgid " Lien Participant  "
 msgstr ""
 
-#: web/b3desk/settings.py:684
+#: web/b3desk/settings.py:687
 msgid ""
 "Bienvenue aux modérateurs. Pour inviter quelqu'un à cette réunion, "
 "envoyez-lui l'un de ces liens :"
@@ -473,7 +473,7 @@ msgstr ""
 #: web/b3desk/templates/brand.html:17 web/b3desk/templates/brand.html:19
 #: web/b3desk/templates/header-lasuite.html:35
 #: web/b3desk/templates/header-lasuite.html:37
-#: web/b3desk/templates/tools.html:48 web/b3desk/templates/tools.html:50
+#: web/b3desk/templates/tools.html:42 web/b3desk/templates/tools.html:44
 msgid "Les services de La Suite numérique"
 msgstr ""
 
@@ -828,24 +828,28 @@ msgstr ""
 msgid "Se connecter ou créer un compte"
 msgstr ""
 
-#: web/b3desk/templates/tools.html:13
+#: web/b3desk/templates/language-selector.html:6
+msgid "Sélectionner une langue"
+msgstr ""
+
+#: web/b3desk/templates/tools.html:7
 msgid "Modalités d'accès"
 msgstr ""
 
-#: web/b3desk/templates/tools.html:30
+#: web/b3desk/templates/tools.html:24
 msgid "Ouvrir la page d'administration"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:81
-#: web/b3desk/templates/tools.html:31
+#: web/b3desk/templates/admin/user_infos.html:81
+#: web/b3desk/templates/tools.html:25
 msgid "Admin"
 msgstr ""
 
-#: web/b3desk/templates/tools.html:39
+#: web/b3desk/templates/tools.html:33
 msgid "se déconnecter"
 msgstr ""
 
-#: web/b3desk/templates/meeting/join.html:42 web/b3desk/templates/tools.html:58
+#: web/b3desk/templates/meeting/join.html:42 web/b3desk/templates/tools.html:52
 msgid "S’identifier"
 msgstr ""
 
@@ -867,20 +871,76 @@ msgstr "Enregistrer un cours"
 msgid "Réunions"
 msgstr "Mon cours"
 
+#: web/b3desk/templates/admin/macros.html:3
+#: web/b3desk/templates/meeting/files.html:188
+#: web/b3desk/templates/meeting/files.html:191
+msgid "Oui"
+msgstr ""
+
+#: web/b3desk/templates/admin/macros.html:5
+#: web/b3desk/templates/meeting/files.html:188
+#: web/b3desk/templates/meeting/files.html:191
+msgid "Non"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:24
+#: web/b3desk/templates/meeting/form.html:56
+msgid "Modifier"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:29
+msgid "Voir le propriétaire"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:43
 #: web/b3desk/templates/admin/meeting_table.html:10
-#: web/b3desk/templates/admin/selected_meeting.html:31
-#: web/b3desk/templates/admin/selected_user.html:33
+#: web/b3desk/templates/admin/user_infos.html:33
 #: web/b3desk/templates/admin/user_table.html:10
 msgid "Identifiant"
 msgstr ""
 
+#: web/b3desk/templates/admin/meeting_infos.html:51
 #: web/b3desk/templates/admin/meeting_table.html:11
-#: web/b3desk/templates/admin/selected_meeting.html:39
-#: web/b3desk/templates/admin/selected_user.html:41
+#: web/b3desk/templates/admin/user_infos.html:41
 #: web/b3desk/templates/admin/user_table.html:11
 #: web/b3desk/templates/footer/donnees_personnelles.html:54
 msgid "Nom"
 msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:59
+msgid "Propriétaire"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:67
+#: web/b3desk/templates/admin/meeting_table.html:34
+msgid "Réunion silencieuse (shadow_meeting)"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:75
+#: web/b3desk/templates/admin/user_infos.html:65
+#, fuzzy
+msgid "Dernière connexion"
+msgstr "Saisir le code de connexion de votre cours"
+
+#: web/b3desk/templates/admin/meeting_infos.html:83
+#: web/b3desk/templates/admin/user_infos.html:73
+msgid "Création"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:91
+#, fuzzy
+msgid "Dernière modification"
+msgstr "Saisir le code de connexion de votre cours"
+
+#: web/b3desk/templates/admin/meeting_infos.html:99
+#, fuzzy
+msgid "n° de téléphone"
+msgstr "Joindre un cours par téléphone"
+
+#: web/b3desk/templates/admin/meeting_infos.html:115
+#, fuzzy
+msgid "Code de connexion (visio_code)"
+msgstr "Saisir le code de connexion de votre cours"
 
 #: web/b3desk/templates/admin/meeting_table.html:12
 msgid "Visio-code"
@@ -896,15 +956,24 @@ msgstr ""
 msgid "Éditer %(meeting_name)s"
 msgstr "Cours « %(meeting_name)s » terminé"
 
-#: web/b3desk/templates/admin/meeting_table.html:34
-#: web/b3desk/templates/admin/selected_meeting.html:65
-msgid "Réunion silencieuse (shadow_meeting)"
-msgstr ""
-
-#: web/b3desk/templates/admin/meetings.html:26
+#: web/b3desk/templates/admin/meetings.html:25
 #, fuzzy
 msgid "Aucune réunion ne correspond à cette recherche."
 msgstr "Aucun cours ne correspond à ces paramètres"
+
+#: web/b3desk/templates/admin/meetings.html:32
+#, fuzzy, python-format
+msgid "%(count)s réunion correspondant aux critères"
+msgid_plural "%(count)s réunions correspondant aux critères"
+msgstr[0] "Aucun cours ne correspond à ces paramètres"
+msgstr[1] ""
+
+#: web/b3desk/templates/admin/meetings.html:38
+#, fuzzy, python-format
+msgid "%(count)s réunion"
+msgid_plural "%(count)s réunions"
+msgstr[0] "Créer un cours"
+msgstr[1] ""
 
 #: web/b3desk/templates/admin/paging.html:7
 #: web/b3desk/templates/admin/paging.html:9
@@ -927,93 +996,42 @@ msgstr ""
 msgid "Dernière page"
 msgstr "Saisir le code de connexion de votre cours"
 
-#: web/b3desk/templates/admin/selected_meeting.html:47
-#, fuzzy
-msgid "Éditer la réunion"
-msgstr "Nom du cours"
-
-#: web/b3desk/templates/admin/selected_meeting.html:50
-#: web/b3desk/templates/admin/selected_meeting.html:51
-#: web/b3desk/templates/meeting/row.html:20
-#: web/b3desk/templates/meeting/row.html:54
-#, python-format
-msgid "Modifier %(meeting_name)s"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:57
-msgid "Propriétaire"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:74
-#: web/b3desk/templates/admin/selected_user.html:65
-#, fuzzy
-msgid "Dernière connexion"
-msgstr "Saisir le code de connexion de votre cours"
-
-#: web/b3desk/templates/admin/selected_meeting.html:82
-#: web/b3desk/templates/admin/selected_user.html:73
-msgid "Création"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:90
-#, fuzzy
-msgid "Dernière modification"
-msgstr "Saisir le code de connexion de votre cours"
-
-#: web/b3desk/templates/admin/selected_meeting.html:98
-#, fuzzy
-msgid "n° de téléphone"
-msgstr "Joindre un cours par téléphone"
-
-#: web/b3desk/templates/admin/selected_meeting.html:114
-#, fuzzy
-msgid "Code de connexion (visio_code)"
-msgstr "Saisir le code de connexion de votre cours"
-
-#: web/b3desk/templates/admin/selected_user.html:49
+#: web/b3desk/templates/admin/user_infos.html:49
 #: web/b3desk/templates/admin/user_table.html:13
 msgid "Email"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:57
+#: web/b3desk/templates/admin/user_infos.html:57
 msgid "Alias"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:90
+#: web/b3desk/templates/admin/user_infos.html:89
 msgid "NC Locator"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:98
+#: web/b3desk/templates/admin/user_infos.html:97
 msgid "NC Login"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:106
+#: web/b3desk/templates/admin/user_infos.html:105
 #, fuzzy
 msgid "NC Dernière connexion"
 msgstr "Saisir le code de connexion de votre cours"
 
-#: web/b3desk/templates/admin/selected_user.html:120
+#: web/b3desk/templates/admin/user_infos.html:119
 #, fuzzy, python-format
 msgid "Liste des réunions de %(fullname)s"
 msgstr "le cours de %(fullname)s"
 
-#: web/b3desk/templates/admin/selected_user.html:124
+#: web/b3desk/templates/admin/user_infos.html:123
 #, python-format
 msgid "%(fullname)s n'a pas créé de réunion."
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:127
+#: web/b3desk/templates/admin/user_infos.html:126
 #, fuzzy
 msgid "Réunions déléguées"
 msgstr "Le cours a des délégataires"
-
-#: web/b3desk/templates/admin/true_false_display.html:2
-msgid "OUI"
-msgstr ""
-
-#: web/b3desk/templates/admin/true_false_display.html:4
-msgid "NON"
-msgstr ""
 
 #: web/b3desk/templates/admin/user_table.html:12
 #: web/b3desk/templates/footer/donnees_personnelles.html:55
@@ -1025,10 +1043,24 @@ msgstr ""
 msgid "%(username)s infos"
 msgstr ""
 
-#: web/b3desk/templates/admin/users.html:26
+#: web/b3desk/templates/admin/users.html:25
 #, fuzzy
 msgid "Aucun utilisateur ne correspond à cette recherche."
 msgstr "Aucun cours ne correspond à ces paramètres"
+
+#: web/b3desk/templates/admin/users.html:32
+#, fuzzy, python-format
+msgid "%(count)s utilisateur correspondant aux critères"
+msgid_plural "%(count)s utilisateurs correspondant aux critères"
+msgstr[0] "Aucun cours ne correspond à ces paramètres"
+msgstr[1] ""
+
+#: web/b3desk/templates/admin/users.html:38
+#, python-format
+msgid "%(count)s utilisateur"
+msgid_plural "%(count)s utilisateurs"
+msgstr[0] ""
+msgstr[1] ""
 
 #: web/b3desk/templates/errors/400.html:7
 msgid "Erreur 400"
@@ -2307,16 +2339,6 @@ msgstr ""
 msgid "Annuler"
 msgstr ""
 
-#: web/b3desk/templates/meeting/files.html:188
-#: web/b3desk/templates/meeting/files.html:191
-msgid "Oui"
-msgstr ""
-
-#: web/b3desk/templates/meeting/files.html:188
-#: web/b3desk/templates/meeting/files.html:191
-msgid "Non"
-msgstr ""
-
 #: web/b3desk/templates/meeting/files.html:213
 msgid "Aucun document de présentation n'est prévu pour cette réunion actuellement"
 msgstr "Aucun document de présentation n'est prévu pour ce cours actuellement"
@@ -2329,10 +2351,6 @@ msgstr ""
 #: web/b3desk/templates/meeting/form.html:11
 #: web/b3desk/templates/meeting/form.html:13
 msgid "Désactivé"
-msgstr ""
-
-#: web/b3desk/templates/meeting/form.html:56
-msgid "Modifier"
 msgstr ""
 
 #: web/b3desk/templates/meeting/form.html:58
@@ -2635,6 +2653,12 @@ msgstr ""
 
 #: web/b3desk/templates/meeting/row.html:17
 msgid "Copier le lien Participant dans le presse-papiers"
+msgstr ""
+
+#: web/b3desk/templates/meeting/row.html:20
+#: web/b3desk/templates/meeting/row.html:54
+#, python-format
+msgid "Modifier %(meeting_name)s"
 msgstr ""
 
 #: web/b3desk/templates/meeting/row.html:22
@@ -5559,5 +5583,14 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Quitter la page d'administration"
+#~ msgstr ""
+
+#~ msgid "Éditer la réunion"
+#~ msgstr "Nom du cours"
+
+#~ msgid "OUI"
+#~ msgstr ""
+
+#~ msgid "NON"
 #~ msgstr ""
 

--- a/web/translations/fr@seminaire/LC_MESSAGES/messages.po
+++ b/web/translations/fr@seminaire/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 10:41+0200\n"
+"POT-Creation-Date: 2026-06-15 17:26+0200\n"
 "PO-Revision-Date: 2026-02-13 14:28+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr@seminaire\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: web/b3desk/__init__.py:291 web/b3desk/endpoints/meeting_files.py:123
+#: web/b3desk/__init__.py:310 web/b3desk/endpoints/meeting_files.py:123
 #: web/b3desk/endpoints/meeting_files.py:182
 #: web/b3desk/endpoints/meeting_files.py:287
 #: web/b3desk/endpoints/meeting_files.py:477
@@ -40,7 +40,7 @@ msgid "Le texte est trop long"
 msgstr ""
 
 #: web/b3desk/forms.py:51 web/b3desk/forms.py:106
-#: web/b3desk/templates/admin/selected_meeting.html:243
+#: web/b3desk/templates/admin/meeting_infos.html:235
 msgid "Salle d'attente"
 msgstr ""
 
@@ -68,7 +68,7 @@ msgstr ""
 msgid "Ma réunion"
 msgstr "Mon séminaire"
 
-#: web/b3desk/forms.py:77 web/b3desk/templates/admin/selected_meeting.html:147
+#: web/b3desk/forms.py:77 web/b3desk/templates/admin/meeting_infos.html:148
 msgid "Texte de bienvenue"
 msgstr ""
 
@@ -83,7 +83,7 @@ msgstr ""
 msgid "Bienvenue dans cette réunion %(meeting_name)s."
 msgstr "Bienvenue dans ce séminaire %(meeting_name)s."
 
-#: web/b3desk/forms.py:89 web/b3desk/templates/admin/selected_meeting.html:122
+#: web/b3desk/forms.py:89 web/b3desk/templates/admin/meeting_infos.html:123
 msgid "Nombre maximal de participants"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 msgid "Limitez vos salons à 350 personnes pour plus de confort."
 msgstr ""
 
-#: web/b3desk/forms.py:94 web/b3desk/templates/admin/selected_meeting.html:139
+#: web/b3desk/forms.py:94 web/b3desk/templates/admin/meeting_infos.html:140
 msgid "Durée maximale (minutes)"
 msgstr ""
 
@@ -103,7 +103,7 @@ msgstr ""
 "A l'issue de cette durée le séminaire stoppe automatiquement. 1h = 60, 2h"
 " = 120, 3h = 180, 4h = 240."
 
-#: web/b3desk/forms.py:113 web/b3desk/templates/admin/selected_meeting.html:180
+#: web/b3desk/forms.py:113 web/b3desk/templates/admin/meeting_infos.html:179
 msgid "Caméras visibles par les modérateurs uniquement"
 msgstr ""
 
@@ -113,7 +113,7 @@ msgid ""
 "participants quand cette option est activée."
 msgstr ""
 
-#: web/b3desk/forms.py:120 web/b3desk/templates/admin/selected_meeting.html:189
+#: web/b3desk/forms.py:120 web/b3desk/templates/admin/meeting_infos.html:187
 msgid "Participants muets à leur arrivée"
 msgstr ""
 
@@ -125,7 +125,7 @@ msgstr ""
 "Vous pouvez choisir de faire arriver les participants dans la salle avec "
 "leur micro fermé, pour un démarrage du séminaire plus calme."
 
-#: web/b3desk/forms.py:127 web/b3desk/templates/admin/selected_meeting.html:198
+#: web/b3desk/forms.py:127 web/b3desk/templates/admin/meeting_infos.html:195
 msgid "Caméras des participants"
 msgstr ""
 
@@ -135,7 +135,7 @@ msgid ""
 "participants."
 msgstr ""
 
-#: web/b3desk/forms.py:135 web/b3desk/templates/admin/selected_meeting.html:207
+#: web/b3desk/forms.py:135 web/b3desk/templates/admin/meeting_infos.html:203
 msgid "Micros des participants"
 msgstr ""
 
@@ -145,19 +145,19 @@ msgid ""
 "participants."
 msgstr ""
 
-#: web/b3desk/forms.py:143 web/b3desk/templates/admin/selected_meeting.html:216
+#: web/b3desk/forms.py:143 web/b3desk/templates/admin/meeting_infos.html:211
 msgid "Discussions privées"
 msgstr ""
 
-#: web/b3desk/forms.py:148 web/b3desk/templates/admin/selected_meeting.html:225
+#: web/b3desk/forms.py:148 web/b3desk/templates/admin/meeting_infos.html:219
 msgid "Discussion publique (tchat)"
 msgstr ""
 
-#: web/b3desk/forms.py:153 web/b3desk/templates/admin/selected_meeting.html:234
+#: web/b3desk/forms.py:153 web/b3desk/templates/admin/meeting_infos.html:227
 msgid "Prise de note collaborative"
 msgstr ""
 
-#: web/b3desk/forms.py:158 web/b3desk/templates/admin/selected_meeting.html:155
+#: web/b3desk/forms.py:158 web/b3desk/templates/admin/meeting_infos.html:156
 msgid "Message à l'attention des modérateurs"
 msgstr ""
 
@@ -173,7 +173,7 @@ msgstr ""
 msgid "Le message est trop long"
 msgstr ""
 
-#: web/b3desk/forms.py:171 web/b3desk/templates/admin/selected_meeting.html:130
+#: web/b3desk/forms.py:171 web/b3desk/templates/admin/meeting_infos.html:131
 msgid "Url de redirection après la réunion"
 msgstr "Url de redirection après le séminaire"
 
@@ -189,7 +189,7 @@ msgstr ""
 msgid "Renouveler le lien participants"
 msgstr ""
 
-#: web/b3desk/forms.py:196 web/b3desk/templates/admin/selected_meeting.html:106
+#: web/b3desk/forms.py:196 web/b3desk/templates/admin/meeting_infos.html:107
 msgid "PIN"
 msgstr ""
 
@@ -222,7 +222,7 @@ msgstr "Code de connexion pour rejoindre le séminaire %(sip)s"
 msgid "(utilisé dans le lien SIP)"
 msgstr ""
 
-#: web/b3desk/forms.py:234 web/b3desk/templates/admin/selected_meeting.html:172
+#: web/b3desk/forms.py:234 web/b3desk/templates/admin/meeting_infos.html:172
 msgid "Enregistrement manuel"
 msgstr ""
 
@@ -230,7 +230,7 @@ msgstr ""
 msgid "Vous pouvez lancer ou arrêter à tout moment l'enregistrement de la salle."
 msgstr ""
 
-#: web/b3desk/forms.py:241 web/b3desk/templates/admin/selected_meeting.html:163
+#: web/b3desk/forms.py:241 web/b3desk/templates/admin/meeting_infos.html:164
 msgid "Enregistrement automatique"
 msgstr ""
 
@@ -248,36 +248,36 @@ msgstr ""
 msgid "Ajout d'utilisateur"
 msgstr ""
 
-#: web/b3desk/forms.py:267 web/b3desk/templates/admin/users.html:20
+#: web/b3desk/forms.py:267 web/b3desk/templates/admin/users.html:19
 msgid "Rechercher un utilisateur"
 msgstr ""
 
-#: web/b3desk/forms.py:274 web/b3desk/templates/admin/meetings.html:20
+#: web/b3desk/forms.py:274 web/b3desk/templates/admin/meetings.html:19
 #, fuzzy
 msgid "Rechercher une réunion"
 msgstr "Créer un séminaire"
 
-#: web/b3desk/settings.py:657 web/b3desk/templates/meeting/list.html:4
+#: web/b3desk/settings.py:660 web/b3desk/templates/meeting/list.html:4
 msgid "Mes salles de réunion"
 msgstr "Mes salles de séminaire"
 
-#: web/b3desk/settings.py:661
+#: web/b3desk/settings.py:664
 msgid "Invitation à une réunion en ligne immédiate du Webinaire de l’Etat"
 msgstr "Invitation à un séminaire en ligne immédiat du Webinaire de l’Etat"
 
-#: web/b3desk/settings.py:674
+#: web/b3desk/settings.py:677
 msgid "Réunion improvisée"
 msgstr "Séminaire improvisé"
 
-#: web/b3desk/settings.py:677
+#: web/b3desk/settings.py:680
 msgid " Lien Modérateur  "
 msgstr ""
 
-#: web/b3desk/settings.py:680
+#: web/b3desk/settings.py:683
 msgid " Lien Participant  "
 msgstr ""
 
-#: web/b3desk/settings.py:684
+#: web/b3desk/settings.py:687
 msgid ""
 "Bienvenue aux modérateurs. Pour inviter quelqu'un à cette réunion, "
 "envoyez-lui l'un de ces liens :"
@@ -473,7 +473,7 @@ msgstr ""
 #: web/b3desk/templates/brand.html:17 web/b3desk/templates/brand.html:19
 #: web/b3desk/templates/header-lasuite.html:35
 #: web/b3desk/templates/header-lasuite.html:37
-#: web/b3desk/templates/tools.html:48 web/b3desk/templates/tools.html:50
+#: web/b3desk/templates/tools.html:42 web/b3desk/templates/tools.html:44
 msgid "Les services de La Suite numérique"
 msgstr ""
 
@@ -828,24 +828,28 @@ msgstr ""
 msgid "Se connecter ou créer un compte"
 msgstr ""
 
-#: web/b3desk/templates/tools.html:13
+#: web/b3desk/templates/language-selector.html:6
+msgid "Sélectionner une langue"
+msgstr ""
+
+#: web/b3desk/templates/tools.html:7
 msgid "Modalités d'accès"
 msgstr ""
 
-#: web/b3desk/templates/tools.html:30
+#: web/b3desk/templates/tools.html:24
 msgid "Ouvrir la page d'administration"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:81
-#: web/b3desk/templates/tools.html:31
+#: web/b3desk/templates/admin/user_infos.html:81
+#: web/b3desk/templates/tools.html:25
 msgid "Admin"
 msgstr ""
 
-#: web/b3desk/templates/tools.html:39
+#: web/b3desk/templates/tools.html:33
 msgid "se déconnecter"
 msgstr ""
 
-#: web/b3desk/templates/meeting/join.html:42 web/b3desk/templates/tools.html:58
+#: web/b3desk/templates/meeting/join.html:42 web/b3desk/templates/tools.html:52
 msgid "S’identifier"
 msgstr ""
 
@@ -867,20 +871,76 @@ msgstr "Enregistrer un séminaire"
 msgid "Réunions"
 msgstr "Mon séminaire"
 
+#: web/b3desk/templates/admin/macros.html:3
+#: web/b3desk/templates/meeting/files.html:188
+#: web/b3desk/templates/meeting/files.html:191
+msgid "Oui"
+msgstr ""
+
+#: web/b3desk/templates/admin/macros.html:5
+#: web/b3desk/templates/meeting/files.html:188
+#: web/b3desk/templates/meeting/files.html:191
+msgid "Non"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:24
+#: web/b3desk/templates/meeting/form.html:56
+msgid "Modifier"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:29
+msgid "Voir le propriétaire"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:43
 #: web/b3desk/templates/admin/meeting_table.html:10
-#: web/b3desk/templates/admin/selected_meeting.html:31
-#: web/b3desk/templates/admin/selected_user.html:33
+#: web/b3desk/templates/admin/user_infos.html:33
 #: web/b3desk/templates/admin/user_table.html:10
 msgid "Identifiant"
 msgstr ""
 
+#: web/b3desk/templates/admin/meeting_infos.html:51
 #: web/b3desk/templates/admin/meeting_table.html:11
-#: web/b3desk/templates/admin/selected_meeting.html:39
-#: web/b3desk/templates/admin/selected_user.html:41
+#: web/b3desk/templates/admin/user_infos.html:41
 #: web/b3desk/templates/admin/user_table.html:11
 #: web/b3desk/templates/footer/donnees_personnelles.html:54
 msgid "Nom"
 msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:59
+msgid "Propriétaire"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:67
+#: web/b3desk/templates/admin/meeting_table.html:34
+msgid "Réunion silencieuse (shadow_meeting)"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:75
+#: web/b3desk/templates/admin/user_infos.html:65
+#, fuzzy
+msgid "Dernière connexion"
+msgstr "Saisir le code de connexion de votre séminaire"
+
+#: web/b3desk/templates/admin/meeting_infos.html:83
+#: web/b3desk/templates/admin/user_infos.html:73
+msgid "Création"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:91
+#, fuzzy
+msgid "Dernière modification"
+msgstr "Saisir le code de connexion de votre séminaire"
+
+#: web/b3desk/templates/admin/meeting_infos.html:99
+#, fuzzy
+msgid "n° de téléphone"
+msgstr "Joindre un séminaire par téléphone"
+
+#: web/b3desk/templates/admin/meeting_infos.html:115
+#, fuzzy
+msgid "Code de connexion (visio_code)"
+msgstr "Saisir le code de connexion de votre séminaire"
 
 #: web/b3desk/templates/admin/meeting_table.html:12
 msgid "Visio-code"
@@ -896,15 +956,24 @@ msgstr ""
 msgid "Éditer %(meeting_name)s"
 msgstr "Séminaire « %(meeting_name)s » terminé"
 
-#: web/b3desk/templates/admin/meeting_table.html:34
-#: web/b3desk/templates/admin/selected_meeting.html:65
-msgid "Réunion silencieuse (shadow_meeting)"
-msgstr ""
-
-#: web/b3desk/templates/admin/meetings.html:26
+#: web/b3desk/templates/admin/meetings.html:25
 #, fuzzy
 msgid "Aucune réunion ne correspond à cette recherche."
 msgstr "Aucun séminaire ne correspond à ces paramètres"
+
+#: web/b3desk/templates/admin/meetings.html:32
+#, fuzzy, python-format
+msgid "%(count)s réunion correspondant aux critères"
+msgid_plural "%(count)s réunions correspondant aux critères"
+msgstr[0] "Aucun séminaire ne correspond à ces paramètres"
+msgstr[1] ""
+
+#: web/b3desk/templates/admin/meetings.html:38
+#, fuzzy, python-format
+msgid "%(count)s réunion"
+msgid_plural "%(count)s réunions"
+msgstr[0] "Créer un séminaire"
+msgstr[1] ""
 
 #: web/b3desk/templates/admin/paging.html:7
 #: web/b3desk/templates/admin/paging.html:9
@@ -927,93 +996,42 @@ msgstr ""
 msgid "Dernière page"
 msgstr "Saisir le code de connexion de votre séminaire"
 
-#: web/b3desk/templates/admin/selected_meeting.html:47
-#, fuzzy
-msgid "Éditer la réunion"
-msgstr "Nom du séminaire"
-
-#: web/b3desk/templates/admin/selected_meeting.html:50
-#: web/b3desk/templates/admin/selected_meeting.html:51
-#: web/b3desk/templates/meeting/row.html:20
-#: web/b3desk/templates/meeting/row.html:54
-#, python-format
-msgid "Modifier %(meeting_name)s"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:57
-msgid "Propriétaire"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:74
-#: web/b3desk/templates/admin/selected_user.html:65
-#, fuzzy
-msgid "Dernière connexion"
-msgstr "Saisir le code de connexion de votre séminaire"
-
-#: web/b3desk/templates/admin/selected_meeting.html:82
-#: web/b3desk/templates/admin/selected_user.html:73
-msgid "Création"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:90
-#, fuzzy
-msgid "Dernière modification"
-msgstr "Saisir le code de connexion de votre séminaire"
-
-#: web/b3desk/templates/admin/selected_meeting.html:98
-#, fuzzy
-msgid "n° de téléphone"
-msgstr "Joindre un séminaire par téléphone"
-
-#: web/b3desk/templates/admin/selected_meeting.html:114
-#, fuzzy
-msgid "Code de connexion (visio_code)"
-msgstr "Saisir le code de connexion de votre séminaire"
-
-#: web/b3desk/templates/admin/selected_user.html:49
+#: web/b3desk/templates/admin/user_infos.html:49
 #: web/b3desk/templates/admin/user_table.html:13
 msgid "Email"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:57
+#: web/b3desk/templates/admin/user_infos.html:57
 msgid "Alias"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:90
+#: web/b3desk/templates/admin/user_infos.html:89
 msgid "NC Locator"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:98
+#: web/b3desk/templates/admin/user_infos.html:97
 msgid "NC Login"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:106
+#: web/b3desk/templates/admin/user_infos.html:105
 #, fuzzy
 msgid "NC Dernière connexion"
 msgstr "Saisir le code de connexion de votre séminaire"
 
-#: web/b3desk/templates/admin/selected_user.html:120
+#: web/b3desk/templates/admin/user_infos.html:119
 #, fuzzy, python-format
 msgid "Liste des réunions de %(fullname)s"
 msgstr "le séminaire de %(fullname)s"
 
-#: web/b3desk/templates/admin/selected_user.html:124
+#: web/b3desk/templates/admin/user_infos.html:123
 #, python-format
 msgid "%(fullname)s n'a pas créé de réunion."
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:127
+#: web/b3desk/templates/admin/user_infos.html:126
 #, fuzzy
 msgid "Réunions déléguées"
 msgstr "Le séminaire a des délégataires"
-
-#: web/b3desk/templates/admin/true_false_display.html:2
-msgid "OUI"
-msgstr ""
-
-#: web/b3desk/templates/admin/true_false_display.html:4
-msgid "NON"
-msgstr ""
 
 #: web/b3desk/templates/admin/user_table.html:12
 #: web/b3desk/templates/footer/donnees_personnelles.html:55
@@ -1025,10 +1043,24 @@ msgstr ""
 msgid "%(username)s infos"
 msgstr ""
 
-#: web/b3desk/templates/admin/users.html:26
+#: web/b3desk/templates/admin/users.html:25
 #, fuzzy
 msgid "Aucun utilisateur ne correspond à cette recherche."
 msgstr "Aucun séminaire ne correspond à ces paramètres"
+
+#: web/b3desk/templates/admin/users.html:32
+#, fuzzy, python-format
+msgid "%(count)s utilisateur correspondant aux critères"
+msgid_plural "%(count)s utilisateurs correspondant aux critères"
+msgstr[0] "Aucun séminaire ne correspond à ces paramètres"
+msgstr[1] ""
+
+#: web/b3desk/templates/admin/users.html:38
+#, python-format
+msgid "%(count)s utilisateur"
+msgid_plural "%(count)s utilisateurs"
+msgstr[0] ""
+msgstr[1] ""
 
 #: web/b3desk/templates/errors/400.html:7
 msgid "Erreur 400"
@@ -2307,16 +2339,6 @@ msgstr ""
 msgid "Annuler"
 msgstr ""
 
-#: web/b3desk/templates/meeting/files.html:188
-#: web/b3desk/templates/meeting/files.html:191
-msgid "Oui"
-msgstr ""
-
-#: web/b3desk/templates/meeting/files.html:188
-#: web/b3desk/templates/meeting/files.html:191
-msgid "Non"
-msgstr ""
-
 #: web/b3desk/templates/meeting/files.html:213
 msgid "Aucun document de présentation n'est prévu pour cette réunion actuellement"
 msgstr "Aucun document de présentation n'est prévu pour ce séminaire actuellement"
@@ -2329,10 +2351,6 @@ msgstr ""
 #: web/b3desk/templates/meeting/form.html:11
 #: web/b3desk/templates/meeting/form.html:13
 msgid "Désactivé"
-msgstr ""
-
-#: web/b3desk/templates/meeting/form.html:56
-msgid "Modifier"
 msgstr ""
 
 #: web/b3desk/templates/meeting/form.html:58
@@ -2636,6 +2654,12 @@ msgstr ""
 
 #: web/b3desk/templates/meeting/row.html:17
 msgid "Copier le lien Participant dans le presse-papiers"
+msgstr ""
+
+#: web/b3desk/templates/meeting/row.html:20
+#: web/b3desk/templates/meeting/row.html:54
+#, python-format
+msgid "Modifier %(meeting_name)s"
 msgstr ""
 
 #: web/b3desk/templates/meeting/row.html:22
@@ -5585,5 +5609,14 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Quitter la page d'administration"
+#~ msgstr ""
+
+#~ msgid "Éditer la réunion"
+#~ msgstr "Nom du séminaire"
+
+#~ msgid "OUI"
+#~ msgstr ""
+
+#~ msgid "NON"
 #~ msgstr ""
 

--- a/web/translations/messages.pot
+++ b/web/translations/messages.pot
@@ -1,4 +1,4 @@
-#: web/b3desk/__init__.py:291 web/b3desk/endpoints/meeting_files.py:123
+#: web/b3desk/__init__.py:310 web/b3desk/endpoints/meeting_files.py:123
 #: web/b3desk/endpoints/meeting_files.py:182
 #: web/b3desk/endpoints/meeting_files.py:287
 #: web/b3desk/endpoints/meeting_files.py:477
@@ -229,27 +229,27 @@ msgstr ""
 msgid "Rechercher une réunion"
 msgstr ""
 
-#: web/b3desk/settings.py:657 web/b3desk/templates/meeting/list.html:4
+#: web/b3desk/settings.py:660 web/b3desk/templates/meeting/list.html:4
 msgid "Mes salles de réunion"
 msgstr ""
 
-#: web/b3desk/settings.py:661
+#: web/b3desk/settings.py:664
 msgid "Invitation à une réunion en ligne immédiate du Webinaire de l’Etat"
 msgstr ""
 
-#: web/b3desk/settings.py:674
+#: web/b3desk/settings.py:677
 msgid "Réunion improvisée"
 msgstr ""
 
-#: web/b3desk/settings.py:677
+#: web/b3desk/settings.py:680
 msgid " Lien Modérateur  "
 msgstr ""
 
-#: web/b3desk/settings.py:680
+#: web/b3desk/settings.py:683
 msgid " Lien Participant  "
 msgstr ""
 
-#: web/b3desk/settings.py:684
+#: web/b3desk/settings.py:687
 msgid ""
 "Bienvenue aux modérateurs. Pour inviter quelqu'un à cette réunion, "
 "envoyez-lui l'un de ces liens :"
@@ -443,7 +443,7 @@ msgstr ""
 #: web/b3desk/templates/brand.html:17 web/b3desk/templates/brand.html:19
 #: web/b3desk/templates/header-lasuite.html:35
 #: web/b3desk/templates/header-lasuite.html:37
-#: web/b3desk/templates/tools.html:48 web/b3desk/templates/tools.html:50
+#: web/b3desk/templates/tools.html:42 web/b3desk/templates/tools.html:44
 msgid "Les services de La Suite numérique"
 msgstr ""
 
@@ -796,24 +796,28 @@ msgstr ""
 msgid "Se connecter ou créer un compte"
 msgstr ""
 
-#: web/b3desk/templates/tools.html:13
+#: web/b3desk/templates/language-selector.html:6
+msgid "Sélectionner une langue"
+msgstr ""
+
+#: web/b3desk/templates/tools.html:7
 msgid "Modalités d'accès"
 msgstr ""
 
-#: web/b3desk/templates/tools.html:30
+#: web/b3desk/templates/tools.html:24
 msgid "Ouvrir la page d'administration"
 msgstr ""
 
 #: web/b3desk/templates/admin/user_infos.html:81
-#: web/b3desk/templates/tools.html:31
+#: web/b3desk/templates/tools.html:25
 msgid "Admin"
 msgstr ""
 
-#: web/b3desk/templates/tools.html:39
+#: web/b3desk/templates/tools.html:33
 msgid "se déconnecter"
 msgstr ""
 
-#: web/b3desk/templates/meeting/join.html:42 web/b3desk/templates/tools.html:58
+#: web/b3desk/templates/meeting/join.html:42 web/b3desk/templates/tools.html:52
 msgid "S’identifier"
 msgstr ""
 

--- a/web/translations/uk/LC_MESSAGES/messages.po
+++ b/web/translations/uk/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 10:41+0200\n"
+"POT-Creation-Date: 2026-06-15 17:26+0200\n"
 "PO-Revision-Date: 2022-04-29 15:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: uk\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: web/b3desk/__init__.py:291 web/b3desk/endpoints/meeting_files.py:123
+#: web/b3desk/__init__.py:310 web/b3desk/endpoints/meeting_files.py:123
 #: web/b3desk/endpoints/meeting_files.py:182
 #: web/b3desk/endpoints/meeting_files.py:287
 #: web/b3desk/endpoints/meeting_files.py:477
@@ -41,7 +41,7 @@ msgid "Le texte est trop long"
 msgstr ""
 
 #: web/b3desk/forms.py:51 web/b3desk/forms.py:106
-#: web/b3desk/templates/admin/selected_meeting.html:243
+#: web/b3desk/templates/admin/meeting_infos.html:235
 msgid "Salle d'attente"
 msgstr ""
 
@@ -66,7 +66,7 @@ msgstr ""
 msgid "Ma réunion"
 msgstr ""
 
-#: web/b3desk/forms.py:77 web/b3desk/templates/admin/selected_meeting.html:147
+#: web/b3desk/forms.py:77 web/b3desk/templates/admin/meeting_infos.html:148
 msgid "Texte de bienvenue"
 msgstr ""
 
@@ -81,7 +81,7 @@ msgstr ""
 msgid "Bienvenue dans cette réunion %(meeting_name)s."
 msgstr ""
 
-#: web/b3desk/forms.py:89 web/b3desk/templates/admin/selected_meeting.html:122
+#: web/b3desk/forms.py:89 web/b3desk/templates/admin/meeting_infos.html:123
 msgid "Nombre maximal de participants"
 msgstr ""
 
@@ -89,7 +89,7 @@ msgstr ""
 msgid "Limitez vos salons à 350 personnes pour plus de confort."
 msgstr ""
 
-#: web/b3desk/forms.py:94 web/b3desk/templates/admin/selected_meeting.html:139
+#: web/b3desk/forms.py:94 web/b3desk/templates/admin/meeting_infos.html:140
 msgid "Durée maximale (minutes)"
 msgstr ""
 
@@ -99,7 +99,7 @@ msgid ""
 " 120, 3h = 180, 4h = 240."
 msgstr ""
 
-#: web/b3desk/forms.py:113 web/b3desk/templates/admin/selected_meeting.html:180
+#: web/b3desk/forms.py:113 web/b3desk/templates/admin/meeting_infos.html:179
 msgid "Caméras visibles par les modérateurs uniquement"
 msgstr ""
 
@@ -109,7 +109,7 @@ msgid ""
 "participants quand cette option est activée."
 msgstr ""
 
-#: web/b3desk/forms.py:120 web/b3desk/templates/admin/selected_meeting.html:189
+#: web/b3desk/forms.py:120 web/b3desk/templates/admin/meeting_infos.html:187
 msgid "Participants muets à leur arrivée"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgid ""
 "leur micro fermé, pour un démarrage de réunion plus calme."
 msgstr ""
 
-#: web/b3desk/forms.py:127 web/b3desk/templates/admin/selected_meeting.html:198
+#: web/b3desk/forms.py:127 web/b3desk/templates/admin/meeting_infos.html:195
 msgid "Caméras des participants"
 msgstr ""
 
@@ -129,7 +129,7 @@ msgid ""
 "participants."
 msgstr ""
 
-#: web/b3desk/forms.py:135 web/b3desk/templates/admin/selected_meeting.html:207
+#: web/b3desk/forms.py:135 web/b3desk/templates/admin/meeting_infos.html:203
 msgid "Micros des participants"
 msgstr ""
 
@@ -139,19 +139,19 @@ msgid ""
 "participants."
 msgstr ""
 
-#: web/b3desk/forms.py:143 web/b3desk/templates/admin/selected_meeting.html:216
+#: web/b3desk/forms.py:143 web/b3desk/templates/admin/meeting_infos.html:211
 msgid "Discussions privées"
 msgstr ""
 
-#: web/b3desk/forms.py:148 web/b3desk/templates/admin/selected_meeting.html:225
+#: web/b3desk/forms.py:148 web/b3desk/templates/admin/meeting_infos.html:219
 msgid "Discussion publique (tchat)"
 msgstr ""
 
-#: web/b3desk/forms.py:153 web/b3desk/templates/admin/selected_meeting.html:234
+#: web/b3desk/forms.py:153 web/b3desk/templates/admin/meeting_infos.html:227
 msgid "Prise de note collaborative"
 msgstr ""
 
-#: web/b3desk/forms.py:158 web/b3desk/templates/admin/selected_meeting.html:155
+#: web/b3desk/forms.py:158 web/b3desk/templates/admin/meeting_infos.html:156
 msgid "Message à l'attention des modérateurs"
 msgstr ""
 
@@ -167,7 +167,7 @@ msgstr ""
 msgid "Le message est trop long"
 msgstr ""
 
-#: web/b3desk/forms.py:171 web/b3desk/templates/admin/selected_meeting.html:130
+#: web/b3desk/forms.py:171 web/b3desk/templates/admin/meeting_infos.html:131
 msgid "Url de redirection après la réunion"
 msgstr ""
 
@@ -183,7 +183,7 @@ msgstr ""
 msgid "Renouveler le lien participants"
 msgstr ""
 
-#: web/b3desk/forms.py:196 web/b3desk/templates/admin/selected_meeting.html:106
+#: web/b3desk/forms.py:196 web/b3desk/templates/admin/meeting_infos.html:107
 msgid "PIN"
 msgstr ""
 
@@ -216,7 +216,7 @@ msgstr ""
 msgid "(utilisé dans le lien SIP)"
 msgstr ""
 
-#: web/b3desk/forms.py:234 web/b3desk/templates/admin/selected_meeting.html:172
+#: web/b3desk/forms.py:234 web/b3desk/templates/admin/meeting_infos.html:172
 msgid "Enregistrement manuel"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "Vous pouvez lancer ou arrêter à tout moment l'enregistrement de la salle."
 msgstr ""
 
-#: web/b3desk/forms.py:241 web/b3desk/templates/admin/selected_meeting.html:163
+#: web/b3desk/forms.py:241 web/b3desk/templates/admin/meeting_infos.html:164
 msgid "Enregistrement automatique"
 msgstr ""
 
@@ -242,35 +242,35 @@ msgstr ""
 msgid "Ajout d'utilisateur"
 msgstr ""
 
-#: web/b3desk/forms.py:267 web/b3desk/templates/admin/users.html:20
+#: web/b3desk/forms.py:267 web/b3desk/templates/admin/users.html:19
 msgid "Rechercher un utilisateur"
 msgstr ""
 
-#: web/b3desk/forms.py:274 web/b3desk/templates/admin/meetings.html:20
+#: web/b3desk/forms.py:274 web/b3desk/templates/admin/meetings.html:19
 msgid "Rechercher une réunion"
 msgstr ""
 
-#: web/b3desk/settings.py:657 web/b3desk/templates/meeting/list.html:4
+#: web/b3desk/settings.py:660 web/b3desk/templates/meeting/list.html:4
 msgid "Mes salles de réunion"
 msgstr ""
 
-#: web/b3desk/settings.py:661
+#: web/b3desk/settings.py:664
 msgid "Invitation à une réunion en ligne immédiate du Webinaire de l’Etat"
 msgstr ""
 
-#: web/b3desk/settings.py:674
+#: web/b3desk/settings.py:677
 msgid "Réunion improvisée"
 msgstr ""
 
-#: web/b3desk/settings.py:677
+#: web/b3desk/settings.py:680
 msgid " Lien Modérateur  "
 msgstr ""
 
-#: web/b3desk/settings.py:680
+#: web/b3desk/settings.py:683
 msgid " Lien Participant  "
 msgstr ""
 
-#: web/b3desk/settings.py:684
+#: web/b3desk/settings.py:687
 msgid ""
 "Bienvenue aux modérateurs. Pour inviter quelqu'un à cette réunion, "
 "envoyez-lui l'un de ces liens :"
@@ -464,7 +464,7 @@ msgstr ""
 #: web/b3desk/templates/brand.html:17 web/b3desk/templates/brand.html:19
 #: web/b3desk/templates/header-lasuite.html:35
 #: web/b3desk/templates/header-lasuite.html:37
-#: web/b3desk/templates/tools.html:48 web/b3desk/templates/tools.html:50
+#: web/b3desk/templates/tools.html:42 web/b3desk/templates/tools.html:44
 msgid "Les services de La Suite numérique"
 msgstr ""
 
@@ -819,24 +819,28 @@ msgstr ""
 msgid "Se connecter ou créer un compte"
 msgstr ""
 
-#: web/b3desk/templates/tools.html:13
+#: web/b3desk/templates/language-selector.html:6
+msgid "Sélectionner une langue"
+msgstr ""
+
+#: web/b3desk/templates/tools.html:7
 msgid "Modalités d'accès"
 msgstr ""
 
-#: web/b3desk/templates/tools.html:30
+#: web/b3desk/templates/tools.html:24
 msgid "Ouvrir la page d'administration"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:81
-#: web/b3desk/templates/tools.html:31
+#: web/b3desk/templates/admin/user_infos.html:81
+#: web/b3desk/templates/tools.html:25
 msgid "Admin"
 msgstr ""
 
-#: web/b3desk/templates/tools.html:39
+#: web/b3desk/templates/tools.html:33
 msgid "se déconnecter"
 msgstr ""
 
-#: web/b3desk/templates/meeting/join.html:42 web/b3desk/templates/tools.html:58
+#: web/b3desk/templates/meeting/join.html:42 web/b3desk/templates/tools.html:52
 msgid "S’identifier"
 msgstr ""
 
@@ -856,19 +860,71 @@ msgstr ""
 msgid "Réunions"
 msgstr ""
 
+#: web/b3desk/templates/admin/macros.html:3
+#: web/b3desk/templates/meeting/files.html:188
+#: web/b3desk/templates/meeting/files.html:191
+msgid "Oui"
+msgstr ""
+
+#: web/b3desk/templates/admin/macros.html:5
+#: web/b3desk/templates/meeting/files.html:188
+#: web/b3desk/templates/meeting/files.html:191
+msgid "Non"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:24
+#: web/b3desk/templates/meeting/form.html:56
+msgid "Modifier"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:29
+msgid "Voir le propriétaire"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:43
 #: web/b3desk/templates/admin/meeting_table.html:10
-#: web/b3desk/templates/admin/selected_meeting.html:31
-#: web/b3desk/templates/admin/selected_user.html:33
+#: web/b3desk/templates/admin/user_infos.html:33
 #: web/b3desk/templates/admin/user_table.html:10
 msgid "Identifiant"
 msgstr ""
 
+#: web/b3desk/templates/admin/meeting_infos.html:51
 #: web/b3desk/templates/admin/meeting_table.html:11
-#: web/b3desk/templates/admin/selected_meeting.html:39
-#: web/b3desk/templates/admin/selected_user.html:41
+#: web/b3desk/templates/admin/user_infos.html:41
 #: web/b3desk/templates/admin/user_table.html:11
 #: web/b3desk/templates/footer/donnees_personnelles.html:54
 msgid "Nom"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:59
+msgid "Propriétaire"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:67
+#: web/b3desk/templates/admin/meeting_table.html:34
+msgid "Réunion silencieuse (shadow_meeting)"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:75
+#: web/b3desk/templates/admin/user_infos.html:65
+msgid "Dernière connexion"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:83
+#: web/b3desk/templates/admin/user_infos.html:73
+msgid "Création"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:91
+msgid "Dernière modification"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:99
+msgid "n° de téléphone"
+msgstr ""
+
+#: web/b3desk/templates/admin/meeting_infos.html:115
+msgid "Code de connexion (visio_code)"
 msgstr ""
 
 #: web/b3desk/templates/admin/meeting_table.html:12
@@ -885,14 +941,25 @@ msgstr ""
 msgid "Éditer %(meeting_name)s"
 msgstr ""
 
-#: web/b3desk/templates/admin/meeting_table.html:34
-#: web/b3desk/templates/admin/selected_meeting.html:65
-msgid "Réunion silencieuse (shadow_meeting)"
-msgstr ""
-
-#: web/b3desk/templates/admin/meetings.html:26
+#: web/b3desk/templates/admin/meetings.html:25
 msgid "Aucune réunion ne correspond à cette recherche."
 msgstr ""
+
+#: web/b3desk/templates/admin/meetings.html:32
+#, python-format
+msgid "%(count)s réunion correspondant aux critères"
+msgid_plural "%(count)s réunions correspondant aux critères"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: web/b3desk/templates/admin/meetings.html:38
+#, python-format
+msgid "%(count)s réunion"
+msgid_plural "%(count)s réunions"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: web/b3desk/templates/admin/paging.html:7
 #: web/b3desk/templates/admin/paging.html:9
@@ -914,85 +981,39 @@ msgstr ""
 msgid "Dernière page"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_meeting.html:47
-msgid "Éditer la réunion"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:50
-#: web/b3desk/templates/admin/selected_meeting.html:51
-#: web/b3desk/templates/meeting/row.html:20
-#: web/b3desk/templates/meeting/row.html:54
-#, python-format
-msgid "Modifier %(meeting_name)s"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:57
-msgid "Propriétaire"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:74
-#: web/b3desk/templates/admin/selected_user.html:65
-msgid "Dernière connexion"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:82
-#: web/b3desk/templates/admin/selected_user.html:73
-msgid "Création"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:90
-msgid "Dernière modification"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:98
-msgid "n° de téléphone"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_meeting.html:114
-msgid "Code de connexion (visio_code)"
-msgstr ""
-
-#: web/b3desk/templates/admin/selected_user.html:49
+#: web/b3desk/templates/admin/user_infos.html:49
 #: web/b3desk/templates/admin/user_table.html:13
 msgid "Email"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:57
+#: web/b3desk/templates/admin/user_infos.html:57
 msgid "Alias"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:90
+#: web/b3desk/templates/admin/user_infos.html:89
 msgid "NC Locator"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:98
+#: web/b3desk/templates/admin/user_infos.html:97
 msgid "NC Login"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:106
+#: web/b3desk/templates/admin/user_infos.html:105
 msgid "NC Dernière connexion"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:120
+#: web/b3desk/templates/admin/user_infos.html:119
 #, python-format
 msgid "Liste des réunions de %(fullname)s"
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:124
+#: web/b3desk/templates/admin/user_infos.html:123
 #, python-format
 msgid "%(fullname)s n'a pas créé de réunion."
 msgstr ""
 
-#: web/b3desk/templates/admin/selected_user.html:127
+#: web/b3desk/templates/admin/user_infos.html:126
 msgid "Réunions déléguées"
-msgstr ""
-
-#: web/b3desk/templates/admin/true_false_display.html:2
-msgid "OUI"
-msgstr ""
-
-#: web/b3desk/templates/admin/true_false_display.html:4
-msgid "NON"
 msgstr ""
 
 #: web/b3desk/templates/admin/user_table.html:12
@@ -1005,9 +1026,25 @@ msgstr ""
 msgid "%(username)s infos"
 msgstr ""
 
-#: web/b3desk/templates/admin/users.html:26
+#: web/b3desk/templates/admin/users.html:25
 msgid "Aucun utilisateur ne correspond à cette recherche."
 msgstr ""
+
+#: web/b3desk/templates/admin/users.html:32
+#, python-format
+msgid "%(count)s utilisateur correspondant aux critères"
+msgid_plural "%(count)s utilisateurs correspondant aux critères"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: web/b3desk/templates/admin/users.html:38
+#, python-format
+msgid "%(count)s utilisateur"
+msgid_plural "%(count)s utilisateurs"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: web/b3desk/templates/errors/400.html:7
 msgid "Erreur 400"
@@ -2282,16 +2319,6 @@ msgstr ""
 msgid "Annuler"
 msgstr ""
 
-#: web/b3desk/templates/meeting/files.html:188
-#: web/b3desk/templates/meeting/files.html:191
-msgid "Oui"
-msgstr ""
-
-#: web/b3desk/templates/meeting/files.html:188
-#: web/b3desk/templates/meeting/files.html:191
-msgid "Non"
-msgstr ""
-
 #: web/b3desk/templates/meeting/files.html:213
 msgid "Aucun document de présentation n'est prévu pour cette réunion actuellement"
 msgstr ""
@@ -2304,10 +2331,6 @@ msgstr ""
 #: web/b3desk/templates/meeting/form.html:11
 #: web/b3desk/templates/meeting/form.html:13
 msgid "Désactivé"
-msgstr ""
-
-#: web/b3desk/templates/meeting/form.html:56
-msgid "Modifier"
 msgstr ""
 
 #: web/b3desk/templates/meeting/form.html:58
@@ -2592,6 +2615,12 @@ msgstr ""
 
 #: web/b3desk/templates/meeting/row.html:17
 msgid "Copier le lien Participant dans le presse-papiers"
+msgstr ""
+
+#: web/b3desk/templates/meeting/row.html:20
+#: web/b3desk/templates/meeting/row.html:54
+#, python-format
+msgid "Modifier %(meeting_name)s"
 msgstr ""
 
 #: web/b3desk/templates/meeting/row.html:22
@@ -6601,5 +6630,14 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Quitter la page d'administration"
+#~ msgstr ""
+
+#~ msgid "Éditer la réunion"
+#~ msgstr ""
+
+#~ msgid "OUI"
+#~ msgstr ""
+
+#~ msgid "NON"
 #~ msgstr ""
 


### PR DESCRIPTION
Menu de sélection de langue qui suit les recommandations du DSFR (affichage, alignement à droite)

https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/selecteur-de-langues

Ça permet de gagner un peu de place en largeur, ce qui est utile pour afficher le bouton « admin » de #361 

<img width="1267" height="232" alt="Capture d’écran du 2026-06-05 17-22-43" src="https://github.com/user-attachments/assets/afa15d44-6abf-4844-858a-4f331c3572e6" />


/cc @Mdl-ac-toulouse